### PR TITLE
Sync Fetch Before Plan

### DIFF
--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -77,6 +77,16 @@ pub fn run(
     // Ensure working directory is clean
     repo.require_clean()?;
 
+    // Determine base branch
+    let base_branch = base.unwrap_or("main");
+
+    // === Phase 0: Fetch base branch to ensure we have latest ===
+    output::info(&format!("Fetching {base_branch}..."));
+    if let Err(e) = repo.fetch(base_branch) {
+        output::warn(&format!("Could not fetch {base_branch}: {e}"));
+        // Continue anyway - we'll work with what we have
+    }
+
     // === Phase 1: Detect and reconcile merged PRs ===
     let reconcile_result = detect_and_reconcile_merged(&repo, &state)?;
 
@@ -99,9 +109,6 @@ pub fn run(
         output::info("No branches in stack - nothing to sync");
         return Ok(());
     }
-
-    // Determine base branch
-    let base_branch = base.unwrap_or("main");
 
     // === Phase 3: Create and execute sync plan ===
     let plan = sync::create_sync_plan(&repo, &stack, base_branch)?;


### PR DESCRIPTION
This pull request refactors the handling of the base branch in the sync workflow to ensure the latest changes from the base branch are fetched before proceeding. The main change is moving the determination of the `base_branch` earlier in the process and adding a fetch step for it, improving reliability when syncing changes.

Improvements to sync workflow:

* The determination of the `base_branch` now happens before any sync operations, ensuring consistency throughout the workflow.
* A new step is added to fetch the latest changes from the `base_branch` (defaulting to `"main"` if not specified), with a warning if the fetch fails, but allowing the process to continue.
* The previous location of base branch determination is removed to avoid redundancy, with all subsequent operations now using the earlier value.