### PR TITLE
chore(ci): add custom CodeQL workflow with path filtering

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,109 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "vscode-extension/**/*.ts"
+      - "vscode-extension/**/*.js"
+      - "vscode-extension/package.json"
+      - ".github/workflows/codeql.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "vscode-extension/**/*.ts"
+      - "vscode-extension/**/*.js"
+      - "vscode-extension/package.json"
+      - ".github/workflows/codeql.yml"
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      typescript: ${{ steps.filter.outputs.typescript }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            typescript:
+              - 'vscode-extension/**/*.ts'
+              - 'vscode-extension/**/*.js'
+              - 'vscode-extension/package.json'
+
+  analyze-rust:
+    name: CodeQL Analyze Rust
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+          build-mode: manual
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust
+        run: cargo build --release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:rust"
+
+  analyze-typescript:
+    name: CodeQL Analyze TypeScript
+    needs: changes
+    if: needs.changes.outputs.typescript == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: vscode-extension
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          build-mode: manual
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build extension
+        run: npm run compile
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
## Summary
- Adds custom CodeQL workflow that only runs on Rust or TypeScript code changes
- Separate analysis jobs for each language, only triggered when relevant files change
- Replaces default GitHub CodeQL setup for more granular control

## Changes
- New `.github/workflows/codeql.yml` with path-based filtering
- Uses `dorny/paths-filter` to detect which language files changed
- Rust analysis runs only on `crates/**`, `Cargo.toml`, `Cargo.lock` changes
- TypeScript analysis runs only on `vscode-extension/**/*.ts` changes

## After Merge
Disable default CodeQL in **Settings → Security → Code security and analysis → Code scanning** to avoid duplicate runs.