### PR TITLE
feat(core): add BranchName newtype with validation

### DIFF
--- a/crates/rung-cli/src/commands/create.rs
+++ b/crates/rung-cli/src/commands/create.rs
@@ -1,13 +1,16 @@
 //! `rung create` command - Create a new branch in the stack.
 
 use anyhow::{Context, Result, bail};
-use rung_core::{State, stack::StackBranch};
+use rung_core::{BranchName, State, stack::StackBranch};
 use rung_git::Repository;
 
 use crate::output;
 
 /// Run the create command.
 pub fn run(name: &str) -> Result<()> {
+    // Validate branch name first
+    let branch_name = BranchName::new(name).context("Invalid branch name")?;
+
     // Open repository
     let repo = Repository::open_current().context("Not inside a git repository")?;
 
@@ -21,7 +24,8 @@ pub fn run(name: &str) -> Result<()> {
     }
 
     // Get current branch (will be parent)
-    let parent = repo.current_branch()?;
+    let parent_str = repo.current_branch()?;
+    let parent = BranchName::new(&parent_str).context("Invalid parent branch name")?;
 
     // Check if branch already exists
     if repo.branch_exists(name) {
@@ -33,7 +37,7 @@ pub fn run(name: &str) -> Result<()> {
 
     // Add to stack
     let mut stack = state.load_stack()?;
-    let branch = StackBranch::new(name, Some(parent.clone()));
+    let branch = StackBranch::new(branch_name, Some(parent.clone()));
     stack.add_branch(branch);
     state.save_stack(&stack)?;
 

--- a/crates/rung-cli/src/commands/status.rs
+++ b/crates/rung-cli/src/commands/status.rs
@@ -42,11 +42,11 @@ pub fn run(json: bool, _fetch: bool) -> Result<()> {
     for branch in &stack.branches {
         let branch_state = compute_branch_state(&repo, branch, &stack)?;
         branches_with_state.push(BranchInfo {
-            name: branch.name.clone(),
-            parent: branch.parent.clone(),
+            name: branch.name.to_string(),
+            parent: branch.parent.as_ref().map(ToString::to_string),
             state: branch_state,
             pr: branch.pr,
-            is_current: current.as_ref() == Some(&branch.name),
+            is_current: current.as_deref() == Some(branch.name.as_str()),
         });
     }
 

--- a/crates/rung-cli/src/commands/submit.rs
+++ b/crates/rung-cli/src/commands/submit.rs
@@ -388,7 +388,7 @@ fn update_stack_comments(gh: &GitHubContext<'_>, branches: &[StackBranch]) -> Re
 /// Returns branch names in order from oldest ancestor to newest descendant.
 fn build_branch_chain(branches: &[StackBranch], current_name: &str) -> Vec<String> {
     // Find all ancestors (walk up the parent chain)
-    let mut ancestors = vec![];
+    let mut ancestors: Vec<String> = vec![];
     let mut current = current_name.to_string();
 
     loop {
@@ -396,8 +396,8 @@ fn build_branch_chain(branches: &[StackBranch], current_name: &str) -> Vec<Strin
             if let Some(ref parent) = branch.parent {
                 // Check if parent is in the stack
                 if branches.iter().any(|b| b.name == *parent) {
-                    ancestors.push(parent.clone());
-                    current = parent.clone();
+                    ancestors.push(parent.to_string());
+                    current = parent.to_string();
                     continue;
                 }
             }
@@ -415,10 +415,12 @@ fn build_branch_chain(branches: &[StackBranch], current_name: &str) -> Vec<Strin
     // Find all descendants (branches whose parent is in our chain)
     let mut i = 0;
     while i < chain.len() {
-        let parent_name = &chain[i].clone();
+        let parent_name = chain[i].clone();
         for branch in branches {
-            if branch.parent.as_ref() == Some(parent_name) && !chain.contains(&branch.name) {
-                chain.push(branch.name.clone());
+            if branch.parent.as_ref().is_some_and(|p| p == &parent_name)
+                && !chain.contains(&branch.name.to_string())
+            {
+                chain.push(branch.name.to_string());
             }
         }
         i += 1;

--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -164,7 +164,7 @@ fn detect_and_reconcile_merged(repo: &Repository, state: &State) -> Result<Recon
     let branches_with_prs: Vec<_> = stack
         .branches
         .iter()
-        .filter_map(|b| b.pr.map(|pr| (b.name.clone(), pr)))
+        .filter_map(|b| b.pr.map(|pr| (b.name.to_string(), pr)))
         .collect();
 
     if branches_with_prs.is_empty() {

--- a/crates/rung-core/src/branch_name.rs
+++ b/crates/rung-core/src/branch_name.rs
@@ -1,0 +1,414 @@
+//! Branch name validation and newtype.
+//!
+//! Provides a [`BranchName`] type that enforces git branch name rules
+//! and prevents security issues like path traversal and shell injection.
+
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::error::Error;
+
+/// A validated git branch name.
+///
+/// This newtype ensures branch names are valid according to git's rules
+/// and don't contain dangerous characters that could enable:
+/// - Path traversal attacks (`../`)
+/// - Shell injection (`$`, `;`, `|`, etc.)
+///
+/// # Examples
+///
+/// ```
+/// use rung_core::BranchName;
+///
+/// // Valid branch names
+/// let name = BranchName::new("feature/auth").unwrap();
+/// let name = BranchName::new("fix-bug-123").unwrap();
+///
+/// // Invalid branch names
+/// assert!(BranchName::new("../etc/passwd").is_err());
+/// assert!(BranchName::new("name;rm -rf").is_err());
+/// assert!(BranchName::new("branch..name").is_err());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BranchName(String);
+
+impl BranchName {
+    /// Create a new validated branch name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidBranchName`] if the name violates git's
+    /// branch naming rules or contains dangerous characters.
+    pub fn new(name: impl Into<String>) -> Result<Self, Error> {
+        let name = name.into();
+        validate_branch_name(&name)?;
+        Ok(Self(name))
+    }
+
+    /// Get the branch name as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the `BranchName` and return the inner `String`.
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl AsRef<str> for BranchName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for BranchName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Display for BranchName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl PartialEq<str> for BranchName {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for BranchName {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<String> for BranchName {
+    fn eq(&self, other: &String) -> bool {
+        self.0 == *other
+    }
+}
+
+impl Serialize for BranchName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for BranchName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::new(s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Validate a branch name against git rules and security constraints.
+fn validate_branch_name(name: &str) -> Result<(), Error> {
+    // Empty name
+    if name.is_empty() {
+        return Err(Error::InvalidBranchName {
+            name: name.to_string(),
+            reason: "branch name cannot be empty".to_string(),
+        });
+    }
+
+    // Single @ is not allowed
+    if name == "@" {
+        return Err(Error::InvalidBranchName {
+            name: name.to_string(),
+            reason: "branch name cannot be '@'".to_string(),
+        });
+    }
+
+    // Cannot start with a dot
+    if name.starts_with('.') {
+        return Err(Error::InvalidBranchName {
+            name: name.to_string(),
+            reason: "branch name cannot start with '.'".to_string(),
+        });
+    }
+
+    // Cannot end with a dot
+    if name.ends_with('.') {
+        return Err(Error::InvalidBranchName {
+            name: name.to_string(),
+            reason: "branch name cannot end with '.'".to_string(),
+        });
+    }
+
+    // Cannot end with .lock (git's rule is case-sensitive)
+    #[allow(clippy::case_sensitive_file_extension_comparisons)]
+    if name.ends_with(".lock") {
+        return Err(Error::InvalidBranchName {
+            name: name.to_string(),
+            reason: "branch name cannot end with '.lock'".to_string(),
+        });
+    }
+
+    // Cannot start or end with a slash
+    if name.starts_with('/') || name.ends_with('/') {
+        return Err(Error::InvalidBranchName {
+            name: name.to_string(),
+            reason: "branch name cannot start or end with '/'".to_string(),
+        });
+    }
+
+    // Check for invalid patterns and characters
+    for (i, c) in name.chars().enumerate() {
+        // Control characters (0x00-0x1f, 0x7f)
+        if c.is_ascii_control() {
+            return Err(Error::InvalidBranchName {
+                name: name.to_string(),
+                reason: "branch name cannot contain control characters".to_string(),
+            });
+        }
+
+        // Git-forbidden characters: space ~ ^ : ? * [
+        if matches!(c, ' ' | '~' | '^' | ':' | '?' | '*' | '[') {
+            return Err(Error::InvalidBranchName {
+                name: name.to_string(),
+                reason: format!("branch name cannot contain '{c}'"),
+            });
+        }
+
+        // Shell metacharacters for security: $ ; | & > < ` \ " ' ( ) { } !
+        if matches!(
+            c,
+            '$' | ';'
+                | '|'
+                | '&'
+                | '>'
+                | '<'
+                | '`'
+                | '\\'
+                | '"'
+                | '\''
+                | '('
+                | ')'
+                | '{'
+                | '}'
+                | '!'
+        ) {
+            return Err(Error::InvalidBranchName {
+                name: name.to_string(),
+                reason: format!("branch name cannot contain shell metacharacter '{c}'"),
+            });
+        }
+
+        // Check for consecutive dots (..)
+        if c == '.' && name.chars().nth(i + 1) == Some('.') {
+            return Err(Error::InvalidBranchName {
+                name: name.to_string(),
+                reason: "branch name cannot contain '..'".to_string(),
+            });
+        }
+
+        // Check for consecutive slashes (//)
+        if c == '/' && name.chars().nth(i + 1) == Some('/') {
+            return Err(Error::InvalidBranchName {
+                name: name.to_string(),
+                reason: "branch name cannot contain '//'".to_string(),
+            });
+        }
+
+        // Check for @{ sequence
+        if c == '@' && name.chars().nth(i + 1) == Some('{') {
+            return Err(Error::InvalidBranchName {
+                name: name.to_string(),
+                reason: "branch name cannot contain '@{'".to_string(),
+            });
+        }
+
+        // Check for slash followed by dot (/.component)
+        if c == '/' && name.chars().nth(i + 1) == Some('.') {
+            return Err(Error::InvalidBranchName {
+                name: name.to_string(),
+                reason: "branch name component cannot start with '.'".to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_branch_names() {
+        // Simple names
+        assert!(BranchName::new("main").is_ok());
+        assert!(BranchName::new("master").is_ok());
+        assert!(BranchName::new("develop").is_ok());
+
+        // With slashes (hierarchical)
+        assert!(BranchName::new("feature/auth").is_ok());
+        assert!(BranchName::new("feature/user/login").is_ok());
+        assert!(BranchName::new("fix/bug-123").is_ok());
+
+        // With dashes and underscores
+        assert!(BranchName::new("my-feature").is_ok());
+        assert!(BranchName::new("my_feature").is_ok());
+        assert!(BranchName::new("feature-123-fix").is_ok());
+
+        // With numbers
+        assert!(BranchName::new("v1.0.0").is_ok());
+        assert!(BranchName::new("release-2024-01").is_ok());
+
+        // With @ (not followed by {)
+        assert!(BranchName::new("user@feature").is_ok());
+    }
+
+    #[test]
+    fn test_empty_name() {
+        let err = BranchName::new("").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+    }
+
+    #[test]
+    fn test_single_at() {
+        let err = BranchName::new("@").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+    }
+
+    #[test]
+    fn test_starts_with_dot() {
+        let err = BranchName::new(".hidden").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+    }
+
+    #[test]
+    fn test_ends_with_dot() {
+        let err = BranchName::new("branch.").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+    }
+
+    #[test]
+    fn test_ends_with_lock() {
+        let err = BranchName::new("branch.lock").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+    }
+
+    #[test]
+    fn test_consecutive_dots() {
+        let err = BranchName::new("branch..name").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+
+        // Path traversal attempt
+        let err = BranchName::new("../etc/passwd").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+    }
+
+    #[test]
+    fn test_slash_rules() {
+        // Starts with slash
+        let err = BranchName::new("/branch").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+
+        // Ends with slash
+        let err = BranchName::new("branch/").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+
+        // Consecutive slashes
+        let err = BranchName::new("feature//auth").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+
+        // Slash followed by dot
+        let err = BranchName::new("feature/.hidden").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+    }
+
+    #[test]
+    fn test_git_forbidden_characters() {
+        for c in [' ', '~', '^', ':', '?', '*', '['] {
+            let name = format!("branch{c}name");
+            let err = BranchName::new(&name).unwrap_err();
+            assert!(matches!(err, Error::InvalidBranchName { .. }), "char: {c}");
+        }
+    }
+
+    #[test]
+    fn test_shell_metacharacters() {
+        for c in [
+            '$', ';', '|', '&', '>', '<', '`', '\\', '"', '\'', '(', ')', '{', '}', '!',
+        ] {
+            let name = format!("branch{c}name");
+            let err = BranchName::new(&name).unwrap_err();
+            assert!(matches!(err, Error::InvalidBranchName { .. }), "char: {c}");
+        }
+    }
+
+    #[test]
+    fn test_shell_injection_attempts() {
+        // Command substitution
+        let err = BranchName::new("branch$(whoami)").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+
+        // Command chaining
+        let err = BranchName::new("branch;rm -rf /").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+
+        // Pipe
+        let err = BranchName::new("branch|cat /etc/passwd").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+    }
+
+    #[test]
+    fn test_at_brace_sequence() {
+        let err = BranchName::new("branch@{1}").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+    }
+
+    #[test]
+    fn test_control_characters() {
+        let err = BranchName::new("branch\x00name").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+
+        let err = BranchName::new("branch\tname").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+
+        let err = BranchName::new("branch\nname").unwrap_err();
+        assert!(matches!(err, Error::InvalidBranchName { .. }));
+    }
+
+    #[test]
+    fn test_display_and_deref() {
+        let name = BranchName::new("feature/auth").unwrap();
+        assert_eq!(format!("{name}"), "feature/auth");
+        assert_eq!(name.as_str(), "feature/auth");
+        assert_eq!(&*name, "feature/auth");
+    }
+
+    #[test]
+    fn test_serialize_deserialize() {
+        let name = BranchName::new("feature/auth").unwrap();
+
+        // Serialize
+        let json = serde_json::to_string(&name).unwrap();
+        assert_eq!(json, "\"feature/auth\"");
+
+        // Deserialize valid
+        let parsed: BranchName = serde_json::from_str("\"feature/test\"").unwrap();
+        assert_eq!(parsed.as_str(), "feature/test");
+
+        // Deserialize invalid should fail
+        let result: Result<BranchName, _> = serde_json::from_str("\"..invalid\"");
+        assert!(result.is_err());
+    }
+}

--- a/crates/rung-core/src/error.rs
+++ b/crates/rung-core/src/error.rs
@@ -20,6 +20,15 @@ pub enum Error {
     #[error("branch not found: {0}")]
     BranchNotFound(String),
 
+    /// Invalid branch name.
+    #[error("invalid branch name '{name}': {reason}")]
+    InvalidBranchName {
+        /// The invalid name.
+        name: String,
+        /// Why the name is invalid.
+        reason: String,
+    },
+
     /// Branch is not part of any stack.
     #[error("branch '{0}' is not part of a rung stack")]
     NotInStack(String),

--- a/crates/rung-core/src/lib.rs
+++ b/crates/rung-core/src/lib.rs
@@ -3,12 +3,14 @@
 //! Core library for Rung providing stack management, state persistence,
 //! and the sync engine for dependent PR stacks.
 
+pub mod branch_name;
 pub mod config;
 pub mod error;
 pub mod stack;
 pub mod state;
 pub mod sync;
 
+pub use branch_name::BranchName;
 pub use config::Config;
 pub use error::{Error, Result};
 pub use stack::{BranchState, Stack, StackBranch};

--- a/crates/rung-core/src/state.rs
+++ b/crates/rung-core/src/state.rs
@@ -352,10 +352,7 @@ mod tests {
         state.init().unwrap();
 
         let mut stack = Stack::new();
-        stack.add_branch(crate::stack::StackBranch::new(
-            "feature/test",
-            Some("main".into()),
-        ));
+        stack.add_branch(crate::stack::StackBranch::try_new("feature/test", Some("main")).unwrap());
 
         state.save_stack(&stack).unwrap();
         let loaded = state.load_stack().unwrap();


### PR DESCRIPTION
## Summary
- Introduce `BranchName` newtype that enforces git branch name rules and prevents security issues at construction time
- Add comprehensive validation for git rules (no `..`, control chars, `~^:?*[`, `@{`) and security (no shell metacharacters)
- Update `StackBranch` to use `BranchName` for `name` and `parent` fields
- Validate branch names at CLI entry points

## Test plan
- [x] All existing tests pass (27 unit tests, 22 integration tests)
- [x] Added 17 new unit tests covering valid names, git rules, and security scenarios
- [x] Clippy passes with no warnings
- [x] Formatting verified with `cargo fmt`

Closes #34