### PR TITLE
feat(security): zeroize authentication tokens from memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 thiserror = "2"
 anyhow = "1"
 
+# Security
+secrecy = "0.10"
+
 # Time
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/crates/rung-github/Cargo.toml
+++ b/crates/rung-github/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["development-tools", "api-bindings"]
 
 [dependencies]
 reqwest = { workspace = true }
+secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rung-github/src/client.rs
+++ b/crates/rung-github/src/client.rs
@@ -2,6 +2,7 @@
 
 use reqwest::Client;
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
+use secrecy::{ExposeSecret, SecretString};
 use serde::de::DeserializeOwned;
 
 use crate::auth::Auth;
@@ -80,7 +81,8 @@ impl ApiPullRequest {
 pub struct GitHubClient {
     client: Client,
     base_url: String,
-    token: String,
+    /// Token stored as `SecretString` for automatic zeroization on drop.
+    token: SecretString,
 }
 
 impl GitHubClient {
@@ -128,7 +130,10 @@ impl GitHubClient {
         let response = self
             .client
             .get(&url)
-            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .header(
+                AUTHORIZATION,
+                format!("Bearer {}", self.token.expose_secret()),
+            )
             .send()
             .await?;
 
@@ -145,7 +150,10 @@ impl GitHubClient {
         let response = self
             .client
             .post(&url)
-            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .header(
+                AUTHORIZATION,
+                format!("Bearer {}", self.token.expose_secret()),
+            )
             .json(body)
             .send()
             .await?;
@@ -163,7 +171,10 @@ impl GitHubClient {
         let response = self
             .client
             .patch(&url)
-            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .header(
+                AUTHORIZATION,
+                format!("Bearer {}", self.token.expose_secret()),
+            )
             .json(body)
             .send()
             .await?;
@@ -181,7 +192,10 @@ impl GitHubClient {
         let response = self
             .client
             .put(&url)
-            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .header(
+                AUTHORIZATION,
+                format!("Bearer {}", self.token.expose_secret()),
+            )
             .json(body)
             .send()
             .await?;
@@ -195,7 +209,10 @@ impl GitHubClient {
         let response = self
             .client
             .delete(&url)
-            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .header(
+                AUTHORIZATION,
+                format!("Bearer {}", self.token.expose_secret()),
+            )
             .send()
             .await?;
 

--- a/crates/rung-github/src/lib.rs
+++ b/crates/rung-github/src/lib.rs
@@ -2,6 +2,11 @@
 //!
 //! GitHub API integration for Rung, providing PR management
 //! and CI status fetching capabilities.
+//!
+//! # Security
+//!
+//! Authentication tokens are stored using `SecretString` which automatically
+//! zeroizes memory when dropped, reducing credential exposure in memory dumps.
 
 mod auth;
 mod client;
@@ -11,6 +16,8 @@ mod types;
 pub use auth::Auth;
 pub use client::GitHubClient;
 pub use error::{Error, Result};
+// Re-export SecretString for constructing Auth::Token
+pub use secrecy::SecretString;
 pub use types::{
     CheckRun, CheckStatus, CreateComment, CreatePullRequest, IssueComment, MergeMethod,
     MergePullRequest, MergeResult, PullRequest, PullRequestState, UpdateComment, UpdatePullRequest,


### PR DESCRIPTION
This pull request introduces improvements to how authentication tokens are handled in the GitHub API integration, focusing on enhancing security by using the `secrecy` crate. The main change is that tokens are now stored and managed as `SecretString`, which ensures they are automatically zeroized from memory when dropped, reducing the risk of credential exposure. This affects both the authentication logic and the GitHub client implementation.

**Security improvements:**

* Authentication tokens are now stored using `SecretString` from the `secrecy` crate, ensuring automatic zeroization of memory and preventing accidental logging. This replaces the previous usage of plain `String` for tokens in both the `Auth` enum and `GitHubClient` struct. [[1]](diffhunk://#diff-52c27deb2069451ae0d1737db9e552936cd6a60a0b9153834886095469bf8c02L21-R24) [[2]](diffhunk://#diff-97dac4f1ed4f56c013d9c034ef74de6aad5e07a5b2de19c6ef0c2e60b1756eacL83-R85) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R39-R41) [[4]](diffhunk://#diff-ae6956b6f960be4af17ca8783e546488471292aa5b3ce0b073aed434e92774f7R15)
* The authentication resolution logic (`Auth::resolve` and related functions) now consistently returns `SecretString`, and all token sources (environment variable, CLI, direct) are wrapped accordingly. [[1]](diffhunk://#diff-52c27deb2069451ae0d1737db9e552936cd6a60a0b9153834886095469bf8c02R42-R51) [[2]](diffhunk://#diff-52c27deb2069451ae0d1737db9e552936cd6a60a0b9153834886095469bf8c02L58-R64) [[3]](diffhunk://#diff-52c27deb2069451ae0d1737db9e552936cd6a60a0b9153834886095469bf8c02L71-R77)

**API client changes:**

* All API requests in `GitHubClient` now use `token.expose_secret()` to safely access the token for HTTP headers, ensuring tokens are only exposed when necessary and otherwise kept protected. [[1]](diffhunk://#diff-97dac4f1ed4f56c013d9c034ef74de6aad5e07a5b2de19c6ef0c2e60b1756eacL131-R136) [[2]](diffhunk://#diff-97dac4f1ed4f56c013d9c034ef74de6aad5e07a5b2de19c6ef0c2e60b1756eacL148-R156) [[3]](diffhunk://#diff-97dac4f1ed4f56c013d9c034ef74de6aad5e07a5b2de19c6ef0c2e60b1756eacL166-R177) [[4]](diffhunk://#diff-97dac4f1ed4f56c013d9c034ef74de6aad5e07a5b2de19c6ef0c2e60b1756eacL184-R198) [[5]](diffhunk://#diff-97dac4f1ed4f56c013d9c034ef74de6aad5e07a5b2de19c6ef0c2e60b1756eacL198-R215)

**Documentation updates:**

* Security notes have been updated across `auth.rs` and `lib.rs` to reflect the use of `SecretString` and its benefits for credential management. [[1]](diffhunk://#diff-52c27deb2069451ae0d1737db9e552936cd6a60a0b9153834886095469bf8c02L3-R11) [[2]](diffhunk://#diff-1b6d68954b39a082599be6da9f852ce5e35a3439cdf64c361b0d4a7504cab4d1R5-R9)

**Public API changes:**

* `SecretString` is now re-exported from the crate, allowing users to construct `Auth::Token` securely from outside the crate.

**Testing updates:**

* Tests for token authentication have been updated to use `SecretString` and its `expose_secret()` method for assertions.

Closes #32 
