### PR TITLE
feat: add JSON output support for status, doctor, sync, submit, and merge commands

### DIFF
--- a/crates/rung-cli/src/commands/mod.rs
+++ b/crates/rung-cli/src/commands/mod.rs
@@ -22,6 +22,12 @@ pub mod update;
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
 pub struct Cli {
+    /// Output as JSON (for tooling integration).
+    ///
+    /// Supported by: status, doctor, sync, submit, merge
+    #[arg(long, global = true)]
+    pub json: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -47,10 +53,6 @@ pub enum Commands {
     /// sync state and PR status.
     #[command(alias = "st")]
     Status {
-        /// Output as JSON (for tooling integration).
-        #[arg(long)]
-        json: bool,
-
         /// Fetch latest PR status from GitHub.
         #[arg(long)]
         fetch: bool,

--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -12,12 +12,37 @@ use rung_core::State;
 use rung_core::sync::{self, ExternalMergeInfo, ReconcileResult, SyncResult};
 use rung_git::Repository;
 use rung_github::{Auth, GitHubClient, PullRequestState, UpdatePullRequest};
+use serde::Serialize;
 
 use crate::output;
 
+/// JSON output for sync command.
+#[derive(Debug, Serialize)]
+struct SyncOutput {
+    status: SyncStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    branches_rebased: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backup_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    conflict_branch: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    conflict_files: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SyncStatus {
+    AlreadySynced,
+    Complete,
+    Conflict,
+    Aborted,
+}
+
 /// Run the sync command.
-#[allow(clippy::fn_params_excessive_bools)]
+#[allow(clippy::fn_params_excessive_bools, clippy::too_many_lines)]
 pub fn run(
+    json: bool,
     dry_run: bool,
     continue_: bool,
     abort: bool,
@@ -47,6 +72,15 @@ pub fn run(
             bail!("No sync in progress to abort");
         }
         sync::abort_sync(&repo, &state)?;
+        if json {
+            return output_json(&SyncOutput {
+                status: SyncStatus::Aborted,
+                branches_rebased: None,
+                backup_id: None,
+                conflict_branch: None,
+                conflict_files: vec![],
+            });
+        }
         output::success("Sync aborted - branches restored from backup");
         return Ok(());
     }
@@ -56,17 +90,19 @@ pub fn run(
         if !state.is_sync_in_progress() {
             bail!("No sync in progress to continue");
         }
-        output::info("Continuing sync...");
+        if !json {
+            output::info("Continuing sync...");
+        }
         let result = sync::continue_sync(&repo, &state)?;
 
         // If sync completed successfully, push the branches
         if let SyncResult::Complete { .. } = &result {
             if !no_push {
-                push_stack_branches(&repo, &state)?;
+                push_stack_branches(&repo, &state, json)?;
             }
         }
 
-        return handle_sync_result(result);
+        return handle_sync_result(result, json);
     }
 
     // Check for existing sync in progress
@@ -81,18 +117,22 @@ pub fn run(
     let base_branch = base.unwrap_or("main");
 
     // === Phase 0: Fetch base branch to ensure we have latest ===
-    output::info(&format!("Fetching {base_branch}..."));
+    if !json {
+        output::info(&format!("Fetching {base_branch}..."));
+    }
     if let Err(e) = repo.fetch(base_branch) {
-        output::warn(&format!("Could not fetch {base_branch}: {e}"));
+        if !json {
+            output::warn(&format!("Could not fetch {base_branch}: {e}"));
+        }
         // Continue anyway - we'll work with what we have
     }
 
     // === Phase 1: Detect and reconcile merged PRs ===
-    let reconcile_result = detect_and_reconcile_merged(&repo, &state)?;
+    let reconcile_result = detect_and_reconcile_merged(&repo, &state, json)?;
 
     // === Phase 2: Remove stale branches ===
     let stale_result = sync::remove_stale_branches(&repo, &state)?;
-    if !stale_result.removed.is_empty() {
+    if !json && !stale_result.removed.is_empty() {
         output::warn(&format!(
             "Removed {} stale branch(es) from stack:",
             stale_result.removed.len()
@@ -106,6 +146,15 @@ pub fn run(
     let stack = state.load_stack()?;
 
     if stack.is_empty() {
+        if json {
+            return output_json(&SyncOutput {
+                status: SyncStatus::AlreadySynced,
+                branches_rebased: Some(0),
+                backup_id: None,
+                conflict_branch: None,
+                conflict_files: vec![],
+            });
+        }
         output::info("No branches in stack - nothing to sync");
         return Ok(());
     }
@@ -114,18 +163,20 @@ pub fn run(
     let plan = sync::create_sync_plan(&repo, &stack, base_branch)?;
 
     if dry_run {
-        output::info("Dry run - would perform the following:");
-        if !reconcile_result.merged.is_empty() {
-            println!("  Merged PRs detected: {}", reconcile_result.merged.len());
-        }
-        if !plan.is_empty() {
-            println!("  Branches to rebase:");
-            for action in &plan.branches {
-                println!(
-                    "    → {} (onto {})",
-                    action.branch,
-                    &action.new_base[..8.min(action.new_base.len())]
-                );
+        if !json {
+            output::info("Dry run - would perform the following:");
+            if !reconcile_result.merged.is_empty() {
+                println!("  Merged PRs detected: {}", reconcile_result.merged.len());
+            }
+            if !plan.is_empty() {
+                println!("  Branches to rebase:");
+                for action in &plan.branches {
+                    println!(
+                        "    → {} (onto {})",
+                        action.branch,
+                        &action.new_base[..8.min(action.new_base.len())]
+                    );
+                }
             }
         }
         return Ok(());
@@ -134,30 +185,36 @@ pub fn run(
     let sync_result = if plan.is_empty() {
         SyncResult::AlreadySynced
     } else {
-        output::info(&format!("Syncing {} branches...", plan.branches.len()));
+        if !json {
+            output::info(&format!("Syncing {} branches...", plan.branches.len()));
+        }
         sync::execute_sync(&repo, &state, plan)?
     };
 
     // If sync paused on conflict, don't proceed with push/update
     if let SyncResult::Paused { .. } = &sync_result {
-        return handle_sync_result(sync_result);
+        return handle_sync_result(sync_result, json);
     }
 
     // === Phase 4: Update GitHub PR base branches ===
     if !reconcile_result.reparented.is_empty() {
-        update_pr_bases(&repo, &reconcile_result)?;
+        update_pr_bases(&repo, &reconcile_result, json)?;
     }
 
     // === Phase 5: Push all branches ===
     if !no_push {
-        push_stack_branches(&repo, &state)?;
+        push_stack_branches(&repo, &state, json)?;
     }
 
-    handle_sync_result(sync_result)
+    handle_sync_result(sync_result, json)
 }
 
 /// Detect merged PRs via GitHub API and reconcile the stack.
-fn detect_and_reconcile_merged(repo: &Repository, state: &State) -> Result<ReconcileResult> {
+fn detect_and_reconcile_merged(
+    repo: &Repository,
+    state: &State,
+    json: bool,
+) -> Result<ReconcileResult> {
     let stack = state.load_stack()?;
 
     // Collect branches with PRs to check
@@ -178,7 +235,9 @@ fn detect_and_reconcile_merged(repo: &Repository, state: &State) -> Result<Recon
 
     let Ok(client) = GitHubClient::new(&Auth::auto()) else {
         // If GitHub auth fails, skip merge detection but continue with sync
-        output::warn("GitHub auth unavailable - skipping merge detection");
+        if !json {
+            output::warn("GitHub auth unavailable - skipping merge detection");
+        }
         return Ok(ReconcileResult::default());
     };
 
@@ -187,7 +246,9 @@ fn detect_and_reconcile_merged(repo: &Repository, state: &State) -> Result<Recon
     // Check each PR's status
     let mut merged_prs = Vec::new();
 
-    output::info("Checking for merged PRs...");
+    if !json {
+        output::info("Checking for merged PRs...");
+    }
 
     for (branch_name, pr_number) in branches_with_prs {
         let pr_result = rt.block_on(client.get_pr(&owner, &repo_name, pr_number));
@@ -195,10 +256,12 @@ fn detect_and_reconcile_merged(repo: &Repository, state: &State) -> Result<Recon
         match pr_result {
             Ok(pr) => {
                 if pr.state == PullRequestState::Merged {
-                    output::success(&format!(
-                        "PR #{} ({}) merged into {}",
-                        pr_number, branch_name, pr.base_branch
-                    ));
+                    if !json {
+                        output::success(&format!(
+                            "PR #{} ({}) merged into {}",
+                            pr_number, branch_name, pr.base_branch
+                        ));
+                    }
 
                     merged_prs.push(ExternalMergeInfo {
                         branch_name,
@@ -209,7 +272,9 @@ fn detect_and_reconcile_merged(repo: &Repository, state: &State) -> Result<Recon
             }
             Err(e) => {
                 // Log but don't fail - PR might have been deleted
-                output::warn(&format!("Could not check PR #{pr_number}: {e}"));
+                if !json {
+                    output::warn(&format!("Could not check PR #{pr_number}: {e}"));
+                }
             }
         }
     }
@@ -222,18 +287,24 @@ fn detect_and_reconcile_merged(repo: &Repository, state: &State) -> Result<Recon
     let result = sync::reconcile_merged(state, &merged_prs)?;
 
     // Report re-parented branches
-    for reparent in &result.reparented {
-        output::info(&format!(
-            "Re-parented {} → {} (was {})",
-            reparent.name, reparent.new_parent, reparent.old_parent
-        ));
+    if !json {
+        for reparent in &result.reparented {
+            output::info(&format!(
+                "Re-parented {} → {} (was {})",
+                reparent.name, reparent.new_parent, reparent.old_parent
+            ));
+        }
     }
 
     Ok(result)
 }
 
 /// Update GitHub PR base branches for re-parented branches.
-fn update_pr_bases(repo: &Repository, reconcile_result: &ReconcileResult) -> Result<()> {
+fn update_pr_bases(
+    repo: &Repository,
+    reconcile_result: &ReconcileResult,
+    json: bool,
+) -> Result<()> {
     let origin_url = repo.origin_url().context("No origin remote configured")?;
     let (owner, repo_name) = Repository::parse_github_remote(&origin_url)
         .context("Could not parse GitHub remote URL")?;
@@ -241,7 +312,9 @@ fn update_pr_bases(repo: &Repository, reconcile_result: &ReconcileResult) -> Res
     let client = GitHubClient::new(&Auth::auto()).context("Failed to authenticate with GitHub")?;
     let rt = tokio::runtime::Runtime::new()?;
 
-    output::info("Updating PR base branches on GitHub...");
+    if !json {
+        output::info("Updating PR base branches on GitHub...");
+    }
 
     for reparent in &reconcile_result.reparented {
         if let Some(pr_number) = reparent.pr_number {
@@ -253,13 +326,17 @@ fn update_pr_bases(repo: &Repository, reconcile_result: &ReconcileResult) -> Res
 
             match rt.block_on(client.update_pr(&owner, &repo_name, pr_number, update)) {
                 Ok(_) => {
-                    output::success(&format!(
-                        "Updated PR #{} base → {}",
-                        pr_number, reparent.new_parent
-                    ));
+                    if !json {
+                        output::success(&format!(
+                            "Updated PR #{} base → {}",
+                            pr_number, reparent.new_parent
+                        ));
+                    }
                 }
                 Err(e) => {
-                    output::warn(&format!("Could not update PR #{pr_number}: {e}"));
+                    if !json {
+                        output::warn(&format!("Could not update PR #{pr_number}: {e}"));
+                    }
                 }
             }
         }
@@ -269,14 +346,16 @@ fn update_pr_bases(repo: &Repository, reconcile_result: &ReconcileResult) -> Res
 }
 
 /// Push all branches in the stack to remote.
-fn push_stack_branches(repo: &Repository, state: &State) -> Result<()> {
+fn push_stack_branches(repo: &Repository, state: &State, json: bool) -> Result<()> {
     let stack = state.load_stack()?;
 
     if stack.is_empty() {
         return Ok(());
     }
 
-    output::info("Pushing to remote...");
+    if !json {
+        output::info("Pushing to remote...");
+    }
 
     let mut pushed = 0;
     for branch in &stack.branches {
@@ -286,13 +365,15 @@ fn push_stack_branches(repo: &Repository, state: &State) -> Result<()> {
                     pushed += 1;
                 }
                 Err(e) => {
-                    output::warn(&format!("Could not push {}: {e}", branch.name));
+                    if !json {
+                        output::warn(&format!("Could not push {}: {e}", branch.name));
+                    }
                 }
             }
         }
     }
 
-    if pushed > 0 {
+    if !json && pushed > 0 {
         output::success(&format!("Pushed {pushed} branch(es)"));
     }
 
@@ -300,15 +381,33 @@ fn push_stack_branches(repo: &Repository, state: &State) -> Result<()> {
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn handle_sync_result(result: SyncResult) -> Result<()> {
+fn handle_sync_result(result: SyncResult, json: bool) -> Result<()> {
     match result {
         SyncResult::AlreadySynced => {
+            if json {
+                return output_json(&SyncOutput {
+                    status: SyncStatus::AlreadySynced,
+                    branches_rebased: Some(0),
+                    backup_id: None,
+                    conflict_branch: None,
+                    conflict_files: vec![],
+                });
+            }
             output::success("Stack is already up-to-date");
         }
         SyncResult::Complete {
             branches_rebased,
             backup_id,
         } => {
+            if json {
+                return output_json(&SyncOutput {
+                    status: SyncStatus::Complete,
+                    branches_rebased: Some(branches_rebased),
+                    backup_id: Some(backup_id),
+                    conflict_branch: None,
+                    conflict_files: vec![],
+                });
+            }
             output::success(&format!(
                 "Synced {branches_rebased} branches (backup: {})",
                 &backup_id[..8.min(backup_id.len())]
@@ -317,8 +416,17 @@ fn handle_sync_result(result: SyncResult) -> Result<()> {
         SyncResult::Paused {
             at_branch,
             conflict_files,
-            ..
+            backup_id,
         } => {
+            if json {
+                return output_json(&SyncOutput {
+                    status: SyncStatus::Conflict,
+                    branches_rebased: None,
+                    backup_id: Some(backup_id),
+                    conflict_branch: Some(at_branch),
+                    conflict_files,
+                });
+            }
             output::warn(&format!("Conflict in branch '{at_branch}'"));
             output::info("Conflicting files:");
             for file in &conflict_files {
@@ -329,5 +437,11 @@ fn handle_sync_result(result: SyncResult) -> Result<()> {
             output::info("Or abort with: rung sync --abort");
         }
     }
+    Ok(())
+}
+
+/// Output sync result as JSON.
+fn output_json(output: &SyncOutput) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(output)?);
     Ok(())
 }

--- a/crates/rung-cli/src/main.rs
+++ b/crates/rung-cli/src/main.rs
@@ -9,28 +9,29 @@ use commands::{Cli, Commands};
 
 fn main() {
     let cli = Cli::parse();
+    let json = cli.json;
 
     let result = match cli.command {
         Commands::Init => commands::init::run(),
         Commands::Create { name } => commands::create::run(&name),
-        Commands::Status { json, fetch } => commands::status::run(json, fetch),
+        Commands::Status { fetch } => commands::status::run(json, fetch),
         Commands::Sync {
             dry_run,
             continue_,
             abort,
             no_push,
             base,
-        } => commands::sync::run(dry_run, continue_, abort, no_push, base.as_deref()),
+        } => commands::sync::run(json, dry_run, continue_, abort, no_push, base.as_deref()),
         Commands::Submit {
             draft,
             force,
             title,
-        } => commands::submit::run(draft, force, title.as_deref()),
+        } => commands::submit::run(json, draft, force, title.as_deref()),
         Commands::Undo => commands::undo::run(),
-        Commands::Merge { method, no_delete } => commands::merge::run(&method, no_delete),
+        Commands::Merge { method, no_delete } => commands::merge::run(json, &method, no_delete),
         Commands::Nxt => commands::navigate::run_next(),
         Commands::Prv => commands::navigate::run_prev(),
-        Commands::Doctor => commands::doctor::run(),
+        Commands::Doctor => commands::doctor::run(json),
         Commands::Update { check } => commands::update::run(check),
     };
 


### PR DESCRIPTION
This pr adds JSON output support for several CLI commands (`doctor`, `merge`, `submit`) in the `rung-cli` crate, enabling easier integration with external tooling. The implementation introduces new output structs, modifies command signatures to accept a global `json` flag, and ensures all user-facing messages are suppressed when JSON output is enabled, returning structured data instead.

**JSON Output Support**

* Added JSON output structs (`DoctorOutput`, `MergeOutput`, `SubmitOutput`, etc.) and serialization logic for the `doctor`, `merge`, and `submit` commands, allowing these commands to output machine-readable results when the `--json` flag is used. [[1]](diffhunk://#diff-fd2304ecf4b6eeefb2517e7061c0fe9a394232713faa9711c0c27c9a93149521R8-R37) [[2]](diffhunk://#diff-1d7bfea7ddb946b9953569f71001f6e2ac57514fe50a925b5c5c125150071e22R8-R25) [[3]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aR12-R45)
* Modified command execution logic to suppress human-readable output and return only JSON when the `json` flag is set, including error and status handling. [[1]](diffhunk://#diff-fd2304ecf4b6eeefb2517e7061c0fe9a394232713faa9711c0c27c9a93149521L50-R174) [[2]](diffhunk://#diff-1d7bfea7ddb946b9953569f71001f6e2ac57514fe50a925b5c5c125150071e22R68-R70) [[3]](diffhunk://#diff-1d7bfea7ddb946b9953569f71001f6e2ac57514fe50a925b5c5c125150071e22R100-R102) [[4]](diffhunk://#diff-1d7bfea7ddb946b9953569f71001f6e2ac57514fe50a925b5c5c125150071e22L113-R129) [[5]](diffhunk://#diff-1d7bfea7ddb946b9953569f71001f6e2ac57514fe50a925b5c5c125150071e22R159-R163) [[6]](diffhunk://#diff-1d7bfea7ddb946b9953569f71001f6e2ac57514fe50a925b5c5c125150071e22R176-R178) [[7]](diffhunk://#diff-1d7bfea7ddb946b9953569f71001f6e2ac57514fe50a925b5c5c125150071e22R194-R223) [[8]](diffhunk://#diff-1d7bfea7ddb946b9953569f71001f6e2ac57514fe50a925b5c5c125150071e22R235-R270) [[9]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aL36-R91) [[10]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aL64-R128) [[11]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aL104-L117) [[12]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aL170-R255) [[13]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aR277) [[14]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aR287) [[15]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aR299-R301) [[16]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aR320-R327)

**CLI Argument Handling**

* Introduced a global `--json` flag to the CLI, replacing per-command flags and making JSON output available to all supported commands. [[1]](diffhunk://#diff-ca5471d7552700de8f78d9554d783f7418e240252c70d293923d5dbe35237f3eR25-R30) [[2]](diffhunk://#diff-ca5471d7552700de8f78d9554d783f7418e240252c70d293923d5dbe35237f3eL50-L53)

**Submit Command Enhancements**

* Extended the `submit` command to provide detailed JSON output, including per-branch submission results and PR URLs, and refactored branch processing to collect this information. [[1]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aR12-R45) [[2]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aL36-R91) [[3]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aL64-R128) [[4]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aL104-L117) [[5]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aL170-R255) [[6]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aR277) [[7]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aR287) [[8]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aR299-R301) [[9]](diffhunk://#diff-6935619ae17640f45bb4912697beb7115d56168cddf79368cf2055e6e1b2031aR320-R327)