### PR TITLE
feat(cli): add shell completions command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ git2 = "0.19"
 
 # CLI
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/rung-cli/Cargo.toml
+++ b/crates/rung-cli/Cargo.toml
@@ -32,6 +32,7 @@ rung-git = { workspace = true }
 rung-github = { workspace = true }
 
 clap = { workspace = true }
+clap_complete = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rung-cli/src/commands/completions.rs
+++ b/crates/rung-cli/src/commands/completions.rs
@@ -1,0 +1,16 @@
+//! Shell completion generation.
+
+use std::io;
+
+use clap::CommandFactory;
+use clap_complete::{Shell, generate};
+
+use super::Cli;
+
+/// Generate shell completions and print to stdout.
+#[allow(clippy::unnecessary_wraps)]
+pub fn run(shell: Shell) -> anyhow::Result<()> {
+    let mut cmd = Cli::command();
+    generate(shell, &mut cmd, "rung", &mut io::stdout());
+    Ok(())
+}

--- a/crates/rung-cli/src/commands/mod.rs
+++ b/crates/rung-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 
 use clap::{Parser, Subcommand};
 
+pub mod completions;
 pub mod create;
 pub mod doctor;
 pub mod init;
@@ -148,5 +149,16 @@ pub enum Commands {
         /// Only check for updates without installing.
         #[arg(long)]
         check: bool,
+    },
+
+    /// Generate shell completions.
+    ///
+    /// Outputs completion script to stdout. Redirect to a file and
+    /// source it in your shell configuration.
+    #[command(alias = "comp")]
+    Completions {
+        /// Shell to generate completions for.
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
     },
 }

--- a/crates/rung-cli/src/main.rs
+++ b/crates/rung-cli/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
         Commands::Prv => commands::navigate::run_prev(),
         Commands::Doctor => commands::doctor::run(json),
         Commands::Update { check } => commands::update::run(check),
+        Commands::Completions { shell } => commands::completions::run(shell),
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
Add `rung completions <shell>` subcommand using `clap_complete`.

## Supported shells
- bash
- zsh
- fish
- powershell
- elvish

## Usage
```bash
# Bash
rung completions bash >> ~/.bashrc

# Zsh
rung completions zsh > ~/.zfunc/_rung

# Fish
rung completions fish > ~/.config/fish/completions/rung.fish
```

Closes #18