### PR TITLE
feat(cli): add interactive move command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Terminal output
 colored = "2"
+inquire = "0.9"
 console = "0.15"
 indicatif = "0.17"
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,23 @@ Navigate to the previous (parent) branch in the stack.
 rung prv
 ```
 
+### `rung move`
+
+Interactive branch picker for quick navigation. Opens a TUI list to select and jump to any branch in the stack.
+
+```bash
+rung move    # or `rung mv`
+```
+
+Displays all branches and highlights the current branch. PR numbers are shown when available:
+
+```
+? Jump to branch:
+  feat/auth #41
+> feat/api #42 ◀
+  feat/ui
+```
+
 ### `rung doctor`
 
 Diagnose issues with the stack and repository. Checks:

--- a/crates/rung-cli/Cargo.toml
+++ b/crates/rung-cli/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { workspace = true }
 serde_json = { workspace = true }
 colored = { workspace = true }
 console = { workspace = true }
+inquire = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rung-cli/src/commands/mod.rs
+++ b/crates/rung-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod create;
 pub mod doctor;
 pub mod init;
 pub mod merge;
+pub mod mv;
 pub mod navigate;
 pub mod status;
 pub mod submit;
@@ -133,6 +134,12 @@ pub enum Commands {
     /// Navigate to the previous branch in the stack (parent).
     #[command(alias = "p")]
     Prv,
+
+    /// Interactive branch picker for quick navigation.
+    ///
+    /// Opens a TUI list to select and jump to any branch in the stack.
+    #[command(alias = "mv")]
+    Move,
 
     /// Diagnose issues with the stack and repository.
     ///

--- a/crates/rung-cli/src/commands/mv.rs
+++ b/crates/rung-cli/src/commands/mv.rs
@@ -1,0 +1,71 @@
+//! `rung move` command - Interactive branch navigation.
+
+use anyhow::{Context, Result, bail};
+use inquire::Select;
+use rung_core::State;
+use rung_git::Repository;
+
+use crate::output;
+
+/// Run the move command - interactive branch picker.
+pub fn run() -> Result<()> {
+    let (repo, state) = open_repo_and_state()?;
+    let current = repo.current_branch()?;
+    let stack = state.load_stack()?;
+
+    if stack.is_empty() {
+        bail!("No branches in stack. Use `rung create <name>` to add one.");
+    }
+
+    // Build display options with visual indicators
+    let options: Vec<String> = stack
+        .branches
+        .iter()
+        .map(|b| {
+            let marker = if b.name == current { " ◀" } else { "" };
+            let pr = b.pr.map(|n| format!(" #{n}")).unwrap_or_default();
+            format!("{}{}{}", b.name, pr, marker)
+        })
+        .collect();
+
+    // Find current branch index for pre-selection
+    let start_idx = stack
+        .branches
+        .iter()
+        .position(|b| b.name == current)
+        .unwrap_or(0);
+
+    let selection = Select::new("Jump to branch:", options)
+        .with_starting_cursor(start_idx)
+        .with_page_size(10)
+        .prompt()
+        .context("Selection cancelled")?;
+
+    // Extract branch name (everything before first space)
+    let branch_name = selection
+        .split_whitespace()
+        .next()
+        .context("Invalid selection")?;
+
+    if branch_name == current {
+        output::info("Already on this branch");
+    } else {
+        repo.checkout(branch_name)?;
+        output::success(&format!("Switched to '{branch_name}'"));
+    }
+
+    Ok(())
+}
+
+/// Helper to open repo and state.
+fn open_repo_and_state() -> Result<(Repository, State)> {
+    let repo = Repository::open_current().context("Not inside a git repository")?;
+    let workdir = repo.workdir().context("Cannot run in bare repository")?;
+    let state = State::new(workdir)?;
+
+    if !state.is_initialized() {
+        bail!("Rung not initialized - run `rung init` first");
+    }
+
+    Ok((repo, state))
+}

--- a/crates/rung-cli/src/main.rs
+++ b/crates/rung-cli/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
         Commands::Merge { method, no_delete } => commands::merge::run(json, &method, no_delete),
         Commands::Nxt => commands::navigate::run_next(),
         Commands::Prv => commands::navigate::run_prev(),
+        Commands::Move => commands::mv::run(),
         Commands::Doctor => commands::doctor::run(json),
         Commands::Update { check } => commands::update::run(check),
         Commands::Completions { shell } => commands::completions::run(shell),

--- a/crates/rung-cli/tests/integration.rs
+++ b/crates/rung-cli/tests/integration.rs
@@ -86,7 +86,8 @@ fn test_help_flag() {
         .stdout(predicate::str::contains("init"))
         .stdout(predicate::str::contains("create"))
         .stdout(predicate::str::contains("status"))
-        .stdout(predicate::str::contains("sync"));
+        .stdout(predicate::str::contains("sync"))
+        .stdout(predicate::str::contains("move"));
 }
 
 #[test]
@@ -372,6 +373,21 @@ fn test_navigate_no_child() {
         .assert()
         .success()
         .stdout(predicate::str::contains("no children"));
+}
+
+// Note: Interactive move command tests are limited because inquire
+// requires a TTY which is not available in the test environment.
+// The command is tested via help output only.
+
+#[test]
+fn test_move_in_help() {
+    // Verify move command is registered and shows in main help
+    rung()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("move"))
+        .stdout(predicate::str::contains("Interactive branch picker"));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Add `rung move` (alias `mv`) command for interactive branch navigation using `inquire`.

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes
- [x] Documentation updated (if applicable)

- **What kind of change does this PR introduce?** Feature

- **What is the current behavior?** Users must use `rung prv` or `rung nxt` repeatedly to navigate large stacks.

- **What is the new behavior (if this is a feature change)?**

TUI list to select and jump to any branch:
```
? Jump to branch:
  feat/auth #41
> feat/api #42 ◀
  feat/ui
```

- **Does this PR introduce a breaking change?** No

- **Other information**: Adds `inquire` dependency for interactive prompts.