### PR TITLE
ci: add Release Drafter for automated changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,58 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "enhancement"
+      - "feature"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "bug"
+      - "fix"
+  - title: "🧹 Maintenance"
+    labels:
+      - "chore"
+      - "dependencies"
+  - title: "📚 Documentation"
+    labels:
+      - "documentation"
+      - "docs"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - "major"
+      - "breaking"
+  minor:
+    labels:
+      - "minor"
+      - "enhancement"
+      - "feature"
+  patch:
+    labels:
+      - "patch"
+      - "bug"
+      - "fix"
+  default: patch
+exclude-labels:
+  - "skip-changelog"
+autolabeler:
+  - label: "chore"
+    title:
+      - "/^chore/i"
+  - label: "enhancement"
+    title:
+      - "/^feat/i"
+  - label: "bug"
+    title:
+      - "/^fix/i"
+  - label: "documentation"
+    title:
+      - "/^docs/i"
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add Release Drafter GitHub Action for automated changelog generation.

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes
- [ ] Documentation updated (if applicable)

- **What kind of change does this PR introduce?** CI/CD improvement

- **What is the current behavior?** Manual changelog creation for releases.

- **What is the new behavior (if this is a feature change)?**

Automatically drafts release notes from merged PRs:
- Auto-labels PRs based on title prefix (`feat:`, `fix:`, `chore:`, `docs:`)
- Groups changes by category (Features, Bug Fixes, Maintenance, Docs)
- Auto-increments version based on labels
- Accumulates changes until release is published

- **Does this PR introduce a breaking change?** No

- **Other information**: N/A