### PR TITLE
fix(ci): use pull_request_target for release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
## Summary

Fix Release Drafter workflow to use `pull_request_target` instead of `pull_request` for the autolabeler feature.

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes
- [ ] Documentation updated (if applicable)

- **What kind of change does this PR introduce?** Bug fix

- **What is the current behavior?** GitHub Actions linter warns about unknown webhook names.

- **What is the new behavior (if this is a feature change)?** Uses `pull_request_target` which is the correct event for autolabeling PRs (runs in base repo context).

- **Does this PR introduce a breaking change?** No

- **Other information**: N/A