### PR TITLE
chore(ci): expand CodeQL path filters to all .github files

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,7 @@ on:
       - "vscode-extension/**/*.ts"
       - "vscode-extension/**/*.js"
       - "vscode-extension/package.json"
-      - ".github/workflows/codeql.yml"
+      - ".github/**"
   pull_request:
     branches: [main]
     paths:
@@ -20,7 +20,7 @@ on:
       - "vscode-extension/**/*.ts"
       - "vscode-extension/**/*.js"
       - "vscode-extension/package.json"
-      - ".github/workflows/codeql.yml"
+      - ".github/**"
 
 permissions:
   security-events: write


### PR DESCRIPTION
This pull request updates the CodeQL workflow trigger paths to ensure that any changes within the `.github` directory trigger the workflow, rather than just changes to the single workflow file.

**Workflow configuration improvements:**

* Updated the `paths` filter in the CodeQL workflow to match all files under `.github/**` instead of only `.github/workflows/codeql.yml`, ensuring the workflow runs for any relevant configuration changes. [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L13-R13) [[2]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L23-R23)