### PR TITLE
Release Drafter Integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           draft: false
           prerelease: ${{ contains(github.ref, '-') }}
-          generate_release_notes: true
 
   # Build binaries for each platform
   build:


### PR DESCRIPTION
This pr makes a small update to the release workflow configuration by removing the automatic generation of release notes during release creation and allowing adopting the release drafters' draft release to be promoted.