### PR TITLE
fix(ci): add CodeQL status check for non-code PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,24 +3,8 @@ name: CodeQL
 on:
   push:
     branches: [main]
-    paths:
-      - "crates/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "vscode-extension/**/*.ts"
-      - "vscode-extension/**/*.js"
-      - "vscode-extension/package.json"
-      - ".github/**"
   pull_request:
     branches: [main]
-    paths:
-      - "crates/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "vscode-extension/**/*.ts"
-      - "vscode-extension/**/*.js"
-      - "vscode-extension/package.json"
-      - ".github/**"
 
 permissions:
   security-events: write
@@ -90,3 +74,20 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:javascript-typescript"
+
+  # Required status check that always passes
+  # This allows PRs with only non-code changes (e.g., README) to merge
+  codeql-status:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    needs: [changes, analyze-rust, analyze-typescript]
+    if: always()
+    steps:
+      - name: Check status
+        run: |
+          if [[ "${{ needs.analyze-rust.result }}" == "failure" ]] || \
+             [[ "${{ needs.analyze-typescript.result }}" == "failure" ]]; then
+            echo "CodeQL analysis failed"
+            exit 1
+          fi
+          echo "CodeQL analysis passed or skipped"


### PR DESCRIPTION
This PR updates the CodeQL workflow configuration to improve handling of non-code changes and ensure required status checks work reliably across all pull requests. The main changes include simplifying workflow triggers and adding a new always-passing status check job.

**Workflow configuration improvements:**

* Removed path filters from the `push` and `pull_request` triggers in `.github/workflows/codeql.yml`, so the workflow now runs for all changes to the `main` branch, not just code-related files.

**Status check enhancements:**

* Added a new `codeql-status` job to `.github/workflows/codeql.yml` that always runs and passes unless CodeQL analysis fails, ensuring PRs with only non-code changes (like documentation updates) can still merge by satisfying required status checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code quality workflow to run on all pull requests and pushes, removing previous path-based restrictions
  * Added a consolidated status check that ensures code analysis passes across all supported languages, providing clearer feedback on PR quality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->