### PR TITLE
feat: add --quiet flag to suppress informational output

### DIFF
--- a/crates/rung-cli/src/commands/mod.rs
+++ b/crates/rung-cli/src/commands/mod.rs
@@ -32,6 +32,13 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub json: bool,
 
+    /// Suppress informational output.
+    ///
+    /// Only errors and essential results (like PR URLs) are printed.
+    /// Exit code 0 indicates success.
+    #[arg(short, long, global = true, conflicts_with = "json")]
+    pub quiet: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/crates/rung-cli/src/commands/submit.rs
+++ b/crates/rung-cli/src/commands/submit.rs
@@ -117,6 +117,13 @@ pub fn run(json: bool, draft: bool, force: bool, custom_title: Option<&str>) -> 
 
     print_summary(created, updated);
 
+    // Output PR URLs for piping (essential output, not suppressed by --quiet)
+    for info in &branch_infos {
+        if let Some(url) = &info.pr_url {
+            output::essential(url);
+        }
+    }
+
     Ok(())
 }
 
@@ -191,7 +198,10 @@ fn process_branches(
             branch_infos.push(BranchSubmitInfo {
                 branch: branch_name.to_string(),
                 pr_number,
-                pr_url: None,
+                pr_url: Some(format!(
+                    "https://github.com/{}/{}/pull/{pr_number}",
+                    gh.owner, gh.repo_name
+                )),
                 action: SubmitAction::Updated,
             });
         } else {

--- a/crates/rung-cli/src/main.rs
+++ b/crates/rung-cli/src/main.rs
@@ -9,6 +9,7 @@ use commands::{Cli, Commands};
 
 fn main() {
     let cli = Cli::parse();
+    output::set_quiet(cli.quiet);
     let json = cli.json;
 
     let result = match cli.command {

--- a/crates/rung-cli/src/output.rs
+++ b/crates/rung-cli/src/output.rs
@@ -1,26 +1,50 @@
 //! Terminal output formatting utilities.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use colored::Colorize;
 use rung_core::BranchState;
 
-/// Print a success message.
-pub fn success(msg: &str) {
-    println!("{} {}", "✓".green(), msg);
+static QUIET_MODE: AtomicBool = AtomicBool::new(false);
+
+/// Set quiet mode globally. Call once at startup.
+pub fn set_quiet(quiet: bool) {
+    QUIET_MODE.store(quiet, Ordering::Relaxed);
 }
 
-/// Print an error message.
+fn is_quiet() -> bool {
+    QUIET_MODE.load(Ordering::Relaxed)
+}
+
+/// Print a success message (suppressed in quiet mode).
+pub fn success(msg: &str) {
+    if !is_quiet() {
+        println!("{} {}", "✓".green(), msg);
+    }
+}
+
+/// Print an error message (always prints to stderr).
 pub fn error(msg: &str) {
     eprintln!("{} {}", "✗".red(), msg);
 }
 
-/// Print a warning message.
+/// Print a warning message (always prints to stderr).
 pub fn warn(msg: &str) {
-    println!("{} {}", "!".yellow(), msg);
+    eprintln!("{} {}", "!".yellow(), msg);
 }
 
-/// Print an info message.
+/// Print an info message (suppressed in quiet mode).
 pub fn info(msg: &str) {
-    println!("{} {}", "→".blue(), msg);
+    if !is_quiet() {
+        println!("{} {}", "→".blue(), msg);
+    }
+}
+
+/// Print essential machine-readable output (always prints).
+///
+/// Use for results that should be available for piping, like PR URLs.
+pub fn essential(msg: &str) {
+    println!("{msg}");
 }
 
 /// Get the status indicator for a branch state.
@@ -52,7 +76,9 @@ pub fn pr_ref(number: Option<u64>) -> String {
     number.map_or_else(String::new, |n| format!("#{n}").dimmed().to_string())
 }
 
-/// Print a horizontal line.
+/// Print a horizontal line (suppressed in quiet mode).
 pub fn hr() {
-    println!("{}", "─".repeat(50).dimmed());
+    if !is_quiet() {
+        println!("{}", "─".repeat(50).dimmed());
+    }
 }

--- a/crates/rung-cli/tests/integration.rs
+++ b/crates/rung-cli/tests/integration.rs
@@ -125,13 +125,13 @@ fn test_init_already_initialized() {
     // First init
     rung().arg("init").current_dir(&temp).assert().success();
 
-    // Second init should warn (exits 0 but shows warning)
+    // Second init should warn (exits 0 but shows warning on stderr)
     rung()
         .arg("init")
         .current_dir(&temp)
         .assert()
         .success()
-        .stdout(predicate::str::contains("already initialized"));
+        .stderr(predicate::str::contains("already initialized"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add a global `--quiet`/`-q` flag that suppresses informational messages. Only errors and essential output (like PR URLs) are printed. Fixes #19.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes
- [ ] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Feature
- **Current behavior**: All informational messages (info, success, warnings) print to stdout
- **New behavior**: 
  - `--quiet`/`-q` flag suppresses `info()`, `success()`, and `hr()` output
  - `warn()` and `error()` always print (to stderr)
  - New `essential()` function for machine-readable output (PR URLs)
  - `--quiet` conflicts with `--json` (mutually exclusive)
- **Breaking changes?**: Yes - `warn()` now outputs to stderr instead of stdout. One test updated accordingly.