### PR TITLE
docs: add --quiet flag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ rung status
 ### Global Options
 
 - `--json` - Output as JSON (for tooling integration). Supported by: `status`, `doctor`, `sync`, `submit`, `merge`
+- `-q, --quiet` - Suppress informational output. Only errors and essential results (like PR URLs) are printed. Exit code 0 indicates success. Cannot be used with `--json`.
 
 ### `rung init`
 


### PR DESCRIPTION
## Summary

Document the `--quiet`/`-q` flag in the README. Relates to #19.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [ ] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Documentation
- **Current behavior**: README does not document the `--quiet` flag
- **New behavior**: README Global Options section includes `--quiet` flag documentation
- **Breaking changes?**: No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-q` / `--quiet` global option to suppress informational output and display only errors and essential results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->