### PR TITLE
feat: add message flag to rung create

### DIFF
--- a/crates/rung-cli/src/commands/create.rs
+++ b/crates/rung-cli/src/commands/create.rs
@@ -1,15 +1,29 @@
 //! `rung create` command - Create a new branch in the stack.
 
 use anyhow::{Context, Result, bail};
-use rung_core::{BranchName, State, stack::StackBranch};
+use rung_core::{BranchName, State, slugify, stack::StackBranch};
 use rung_git::Repository;
 
 use crate::output;
 
 /// Run the create command.
-pub fn run(name: &str) -> Result<()> {
-    // Validate branch name first
-    let branch_name = BranchName::new(name).context("Invalid branch name")?;
+pub fn run(name: Option<&str>, message: Option<&str>) -> Result<()> {
+    // Determine the branch name: explicit > derived from message > error
+    let name = match (name, message) {
+        (Some(n), _) => n.to_string(),
+        (None, Some(msg)) => slugify(msg),
+        (None, None) => bail!("Either a branch name or --message must be provided"),
+    };
+
+    // Validate branch name
+    let branch_name = BranchName::new(&name).context("Invalid branch name")?;
+
+    // Validate message content (even when name is provided explicitly)
+    if let Some(msg) = message {
+        if slugify(msg).is_empty() {
+            bail!("Commit message must contain at least one alphanumeric character");
+        }
+    }
 
     // Open repository
     let repo = Repository::open_current().context("Not inside a git repository")?;
@@ -28,12 +42,12 @@ pub fn run(name: &str) -> Result<()> {
     let parent = BranchName::new(&parent_str).context("Invalid parent branch name")?;
 
     // Check if branch already exists
-    if repo.branch_exists(name) {
+    if repo.branch_exists(&name) {
         bail!("Branch '{name}' already exists");
     }
 
-    // Create the branch
-    repo.create_branch(name)?;
+    // Create the branch at current HEAD (parent's tip)
+    repo.create_branch(&name)?;
 
     // Add to stack
     let mut stack = state.load_stack()?;
@@ -42,12 +56,29 @@ pub fn run(name: &str) -> Result<()> {
     state.save_stack(&stack)?;
 
     // Checkout the new branch
-    repo.checkout(name)?;
+    repo.checkout(&name)?;
+
+    // If message is provided, stage all changes and create a commit on the NEW branch
+    if let Some(msg) = message {
+        // Check for changes before staging to provide clearer feedback
+        if repo.is_clean()? {
+            output::warn("Working directory is clean - branch created without commit");
+        } else {
+            repo.stage_all().context("Failed to stage changes")?;
+
+            if repo.has_staged_changes()? {
+                repo.create_commit(msg).context("Failed to create commit")?;
+                output::info(&format!("Created commit: {msg}"));
+            } else {
+                output::warn("No staged changes to commit (untracked files may exist)");
+            }
+        }
+    }
 
     output::success(&format!("Created branch '{name}' with parent '{parent}'"));
 
     // Show position in stack
-    let ancestry = stack.ancestry(name);
+    let ancestry = stack.ancestry(&name);
     if ancestry.len() > 1 {
         output::info(&format!("Stack depth: {}", ancestry.len()));
     }

--- a/crates/rung-cli/src/commands/mod.rs
+++ b/crates/rung-cli/src/commands/mod.rs
@@ -52,10 +52,23 @@ pub enum Commands {
     /// Create a new branch in the stack.
     ///
     /// Creates a new branch with the current branch as its parent.
+    /// Optionally stages all changes and creates a commit with the given message.
+    ///
+    /// If --message is provided without a branch name, the name is derived
+    /// from the commit message (e.g., "feat: add auth" becomes "feat-add-auth").
     #[command(alias = "c")]
+    #[command(group(
+        clap::ArgGroup::new("create_input")
+            .required(true)
+            .args(["name", "message"])
+    ))]
     Create {
-        /// Name of the new branch.
-        name: String,
+        /// Name of the new branch. Optional if --message is provided.
+        name: Option<String>,
+
+        /// Commit message. If provided, stages all changes and creates a commit.
+        #[arg(long, short)]
+        message: Option<String>,
     },
 
     /// Display the current stack status.

--- a/crates/rung-cli/src/main.rs
+++ b/crates/rung-cli/src/main.rs
@@ -14,7 +14,9 @@ fn main() {
 
     let result = match cli.command {
         Commands::Init => commands::init::run(),
-        Commands::Create { name } => commands::create::run(&name),
+        Commands::Create { name, message } => {
+            commands::create::run(name.as_deref(), message.as_deref())
+        }
         Commands::Status { fetch } => commands::status::run(json, fetch),
         Commands::Sync {
             dry_run,

--- a/crates/rung-core/src/lib.rs
+++ b/crates/rung-core/src/lib.rs
@@ -10,7 +10,7 @@ pub mod stack;
 pub mod state;
 pub mod sync;
 
-pub use branch_name::BranchName;
+pub use branch_name::{BranchName, slugify};
 pub use config::Config;
 pub use error::{Error, Result};
 pub use stack::{BranchState, Stack, StackBranch};


### PR DESCRIPTION
## Summary

Add `--message` / `-m` flag to `rung create` that stages all changes, creates a commit, and derives the branch name from the commit message.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Feature
- **Current behavior**: `rung create <name>` requires explicit branch name, user must manually commit
- **New behavior**: 
  - `rung create -m "feat: add auth"` derives branch name (`feat-add-auth`) and commits
  - `rung submit` uses commit message as PR title instead of slugifying branch name
  - Added `slugify()` helper and `BranchName::from_message()` to rung-core
- **Breaking changes?**: No - existing `rung create <name>` still works

## Other Information

- Branch names are truncated to 50 characters at word boundaries
- Empty/emoji-only messages return an error