### PR TITLE
chore: simplify stack comment format

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,11 +319,9 @@ rung merge                  # Merge the next PR
 When you submit PRs, rung adds a comment to each PR showing the stack hierarchy:
 
 ```
-### Stack
-
-- API Tests #124 👈
-- API Client #123
-- `main`
+* **#124** 👈
+* **#123**
+* `main`
 
 ---
 *Managed by [rung](https://github.com/auswm85/rung)*

--- a/crates/rung-cli/src/commands/submit.rs
+++ b/crates/rung-cli/src/commands/submit.rs
@@ -414,7 +414,7 @@ const STACK_COMMENT_MARKER: &str = "<!-- rung-stack -->";
 /// Generate stack comment for a PR.
 fn generate_stack_comment(branches: &[StackBranch], current_pr: u64) -> String {
     let mut comment = String::from(STACK_COMMENT_MARKER);
-    comment.push_str("\n### Stack\n\n");
+    comment.push('\n');
 
     // Find the current branch
     let current_branch = branches.iter().find(|b| b.pr == Some(current_pr));
@@ -432,14 +432,10 @@ fn generate_stack_comment(branches: &[StackBranch], current_pr: u64) -> String {
             let pointer = if is_current { " 👈" } else { "" };
 
             if let Some(pr_num) = b.pr {
-                let title = generate_title(&b.name);
-                if is_current {
-                    let _ = writeln!(comment, "- **{title}** #{pr_num}{pointer}");
-                } else {
-                    let _ = writeln!(comment, "- {title} #{pr_num}");
-                }
+                // GitHub auto-links and expands #number to show PR title
+                let _ = writeln!(comment, "* **#{pr_num}**{pointer}");
             } else {
-                let _ = writeln!(comment, "- *(pending)* `{branch_name}`{pointer}");
+                let _ = writeln!(comment, "* *(pending)* `{branch_name}`{pointer}");
             }
         }
     }
@@ -463,7 +459,7 @@ fn generate_stack_comment(branches: &[StackBranch], current_pr: u64) -> String {
         })
         .unwrap_or("main");
 
-    let _ = writeln!(comment, "- `{base}`");
+    let _ = writeln!(comment, "* `{base}`");
     comment.push_str("\n---\n*Managed by [rung](https://github.com/auswm85/rung)*");
 
     comment


### PR DESCRIPTION
## Summary

Simplify stack comment format to use GitHub's auto-linking feature. Now displays `* **#61**` instead of verbose generated titles.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [ ] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Chore/Refactor
- **Current behavior**: Stack comments showed verbose generated titles like "Docs Update Readme For Message Flag docs: update README for message flag #60"
- **New behavior**: Stack comments show clean format `* **#60**` - GitHub auto-expands to show PR title
- **Breaking changes?**: No

## Other Information

Removes unused `pr_title` field from `StackBranch` since we no longer need to store titles.