### PR TITLE
feat: support NO_COLOR environment variable

### DIFF
--- a/crates/rung-cli/src/main.rs
+++ b/crates/rung-cli/src/main.rs
@@ -8,6 +8,11 @@ mod output;
 use commands::{Cli, Commands};
 
 fn main() {
+    // Respect NO_COLOR environment variable (https://no-color.org/)
+    if std::env::var("NO_COLOR").is_ok() {
+        colored::control::set_override(false);
+    }
+
     let cli = Cli::parse();
     output::set_quiet(cli.quiet);
     let json = cli.json;


### PR DESCRIPTION
## Summary

Respect the `NO_COLOR` environment variable per https://no-color.org/. When set, disable colored output.

Fixes #20

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes
- [ ] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [ ] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Feature
- **Current behavior**: Colored output regardless of environment
- **New behavior**: When `NO_COLOR` env var is set (any value), colors are disabled
- **Breaking changes?**: No

## Other Information

Uses `colored::control::set_override(false)` to globally disable colors when `NO_COLOR` is detected at startup.