### PR TITLE
feat(submit): add --dry-run flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Push all stack branches and create/update PRs on GitHub. Each PR includes a stac
 
 ```bash
 rung submit                          # Submit all branches
+rung submit --dry-run                # Preview what would happen without updating anything
 rung submit --draft                  # Create PRs as drafts
 rung submit --force                  # Force push
 rung submit --title "My PR title"    # Custom title (overrides commit message)

--- a/crates/rung-cli/src/commands/mod.rs
+++ b/crates/rung-cli/src/commands/mod.rs
@@ -119,6 +119,10 @@ pub enum Commands {
         #[arg(long)]
         draft: bool,
 
+        /// Show what would be done without making changes.
+        #[arg(long)]
+        dry_run: bool,
+
         /// Force push even if lease check fails.
         #[arg(long)]
         force: bool,

--- a/crates/rung-cli/src/main.rs
+++ b/crates/rung-cli/src/main.rs
@@ -32,9 +32,10 @@ fn main() {
         } => commands::sync::run(json, dry_run, continue_, abort, no_push, base.as_deref()),
         Commands::Submit {
             draft,
+            dry_run,
             force,
             title,
-        } => commands::submit::run(json, draft, force, title.as_deref()),
+        } => commands::submit::run(json, dry_run, draft, force, title.as_deref()),
         Commands::Undo => commands::undo::run(),
         Commands::Merge { method, no_delete } => commands::merge::run(json, &method, no_delete),
         Commands::Nxt => commands::navigate::run_next(),


### PR DESCRIPTION
## Summary

Implements #67

Adds a dry-run option to the `rung submit` command to preview changes that would be made without actually updating or creating pull requests.

currently i dont see any tests for the `submit` subcommand at all, so im not positive what the right direction might look like to verify that no state changes happen when `--dry-run` is called

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
  - the files i changed should be formatted correctly but `cargo fmt` seems to change a bunch of files 
- [ ] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: (Bug fix, feature, refactor, etc.)
Feature
- **Current behavior**:
Can't run `submit` with `--dry-run`
- **New behavior**:
Can run `submit` with `--dry-run`
- **Breaking changes?**: (If yes, please describe the migration path)

## Other Information
