### PR TITLE
fix: retain merged branch history in stack

### DIFF
--- a/crates/rung-cli/src/commands/merge.rs
+++ b/crates/rung-cli/src/commands/merge.rs
@@ -206,8 +206,12 @@ pub fn run(json: bool, method: &str, no_delete: bool) -> Result<()> {
                 }
             }
 
-            // Remove the merged branch from stack
-            stack.branches.retain(|b| b.name != current_branch);
+            // Mark the branch as merged (moves to merged list for history retention)
+            stack.mark_merged(&current_branch);
+
+            // Clear merged history when entire stack is done
+            stack.clear_merged_if_empty();
+
             state.save_stack(&stack)?;
 
             if !json && children_count > 0 {


### PR DESCRIPTION
## Summary

Retain merged branch history in stack PR comments. After merging a PR, sibling PRs now show the merged branch with strikethrough instead of losing it entirely.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Bug fix
- **Current behavior**: When a branch is merged via `rung merge`, it is removed from `stack.json`. Subsequent `rung submit` regenerates stack comments without the merged branch, losing history context.
- **New behavior**: Merged branches are tracked in a `merged` array in `stack.json`. Stack comments show merged PRs with strikethrough and checkmark: `~~**#26**~~ ✓`. When the entire stack is merged, the `merged` array is cleared.
- **Breaking changes?**: No. Uses `#[serde(default)]` for backwards compatibility with existing `stack.json` files.

## Other Information

Example stack comment after merging #26:
```
* **#28** 👈
* **#27**
* ~~**#26**~~ ✓
* `main`
```