### PR TITLE
fix: preserve original parent for merged branches

### DIFF
--- a/crates/rung-cli/src/commands/merge.rs
+++ b/crates/rung-cli/src/commands/merge.rs
@@ -207,7 +207,9 @@ pub fn run(json: bool, method: &str, no_delete: bool) -> Result<()> {
             }
 
             // Mark the branch as merged (moves to merged list for history retention)
-            stack.mark_merged(&current_branch);
+            stack
+                .mark_merged(&current_branch)
+                .ok_or_else(|| anyhow::anyhow!("Branch '{current_branch}' missing from stack"))?;
 
             // Clear merged history when entire stack is done
             stack.clear_merged_if_empty();

--- a/crates/rung-core/src/stack.rs
+++ b/crates/rung-core/src/stack.rs
@@ -55,7 +55,8 @@ impl Stack {
 
     /// Mark a branch as merged, moving it from active to merged list.
     ///
-    /// This preserves the branch info for stack comment history.
+    /// This preserves the branch info for stack comment history,
+    /// including the original parent for ancestry chain traversal.
     /// Returns the removed branch if found.
     pub fn mark_merged(&mut self, name: &str) -> Option<StackBranch> {
         let branch = self.remove_branch(name)?;
@@ -63,6 +64,7 @@ impl Stack {
         if let Some(pr) = branch.pr {
             self.merged.push(MergedBranch {
                 name: branch.name.clone(),
+                parent: branch.parent.clone(),
                 pr,
                 merged_at: Utc::now(),
             });
@@ -214,6 +216,10 @@ impl StackBranch {
 pub struct MergedBranch {
     /// Branch name.
     pub name: BranchName,
+
+    /// Original parent branch name (preserved for ancestry chain).
+    #[serde(default)]
+    pub parent: Option<BranchName>,
 
     /// PR number that was merged.
     pub pr: u64,


### PR DESCRIPTION
## Summary

Fix merged PRs not appearing in stack comments after `rung merge`. Addresses review comments from PR #80.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Bug fix
- **Current behavior**: After `rung merge`, children are re-parented before `mark_merged` is called, so merged branches have no active branch referencing them. Stack comments lose the merged branch history.
- **New behavior**: 
  - `MergedBranch` now stores `parent` field to preserve original ancestry
  - `build_branch_chain` walks through merged branch parents to build complete history
  - `mark_merged` returns error if branch is missing (fail fast)
- **Breaking changes?**: No. Uses `#[serde(default)]` on `parent` field for backward compatibility.

## Other Information

Fixes CodeRabbit review comments from PR #80:
1. Handle missing branch when marking merged (minor)
2. Preserve parent relationship for merged branches (major)