### PR TITLE
docs: add restack command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,36 @@ Displays all branches and highlights the current branch. PR numbers are shown wh
   feat/ui
 ```
 
+### `rung restack`
+
+Move a branch to a different parent in the stack by rebasing it onto a new base.
+
+```bash
+rung restack --onto main              # Move current branch onto main
+rung restack feature/api --onto main  # Move specific branch
+rung restack --onto feature/base --include-children  # Also move descendants
+rung restack --dry-run                # Preview what would happen
+```
+
+If conflicts occur:
+
+```bash
+# Resolve conflicts, then:
+git add .
+rung restack --continue
+
+# Or abort and restore:
+rung restack --abort
+```
+
+**Options:**
+
+- `--onto <branch>` - New parent branch to rebase onto (interactive selection if not specified)
+- `--include-children` - Also rebase all descendant branches
+- `--dry-run` - Show what would be done without making changes
+- `--continue` - Continue after resolving conflicts
+- `--abort` - Abort and restore from backup
+
 ### `rung log`
 
 Show commits on the current branch (commits between parent branch and HEAD). Helps visualize what's in the current stack branch.

--- a/docs/design.md
+++ b/docs/design.md
@@ -76,14 +76,15 @@ A visual "HUD" for the CLI.
 
 ## 6. Preliminary Command Map
 
-| Command       | Alias   | Description                                     |
-| :------------ | :------ | :---------------------------------------------- |
-| `rung status` | `rg st` | Display the current stack tree and PR links.    |
-| `rung sync`   | `rg sy` | Update the whole stack against the base branch. |
-| `rung nxt`    | `rg n`  | Quickly navigate up the current stack.          |
-| `rung prv`    | `rg p`  | Quickly navigate down the current stack.        |
-| `rung submit` | `rg sm` | Push all changes and update/create GitHub PRs.  |
-| `rung undo`   | `rg un` | Revert the last sync or rebase operation.       |
+| Command        | Alias   | Description                                     |
+| :------------- | :------ | :---------------------------------------------- |
+| `rung status`  | `rg st` | Display the current stack tree and PR links.    |
+| `rung sync`    | `rg sy` | Update the whole stack against the base branch. |
+| `rung restack` | `rg re` | Move a branch to a different parent in stack.   |
+| `rung nxt`     | `rg n`  | Quickly navigate up the current stack.          |
+| `rung prv`     | `rg p`  | Quickly navigate down the current stack.        |
+| `rung submit`  | `rg sm` | Push all changes and update/create GitHub PRs.  |
+| `rung undo`    | `rg un` | Revert the last sync or rebase operation.       |
 
 ---
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -38,6 +38,7 @@ export default defineConfig({
             { label: "sync", slug: "commands/sync" },
             { label: "submit", slug: "commands/submit" },
             { label: "merge", slug: "commands/merge" },
+            { label: "restack", slug: "commands/restack" },
             {
               label: "navigation (nxt, prv, move)",
               slug: "commands/navigation",

--- a/site/src/content/docs/commands/index.md
+++ b/site/src/content/docs/commands/index.md
@@ -26,6 +26,7 @@ These options work with most commands:
 | [`sync`](/commands/sync/)               | `sy`   | Rebase all branches when parents move |
 | [`submit`](/commands/submit/)           | `sm`   | Push branches and create/update PRs   |
 | [`merge`](/commands/merge/)             | `m`    | Merge PR and update the stack         |
+| [`restack`](/commands/restack/)         | `re`   | Move branch to different parent       |
 | [`nxt`](/commands/navigation/)          | `n`    | Navigate to child branch              |
 | [`prv`](/commands/navigation/)          | `p`    | Navigate to parent branch             |
 | [`move`](/commands/navigation/)         | `mv`   | Interactive branch picker             |
@@ -69,6 +70,14 @@ rung log                             # Show branch commits
 rung merge                           # Squash merge (default)
 rung merge --method merge            # Regular merge
 rung merge --method rebase           # Rebase merge
+```
+
+### Restacking
+
+```bash
+rung restack --onto main             # Move current branch onto main
+rung restack feat/api --onto main    # Move specific branch
+rung restack --onto main --include-children  # Also move descendants
 ```
 
 ### Absorbing Changes

--- a/site/src/content/docs/commands/restack.md
+++ b/site/src/content/docs/commands/restack.md
@@ -1,0 +1,155 @@
+---
+title: restack
+description: Move a branch to a different parent in the stack by rebasing it onto a new base.
+---
+
+Move a branch to a different parent in the stack. This is useful when you need to reorganize your stack topology—for example, moving a feature branch from one parent to another.
+
+## Usage
+
+```bash
+rung restack --onto main
+rung restack feature/api --onto main
+rung restack --onto feature/base --include-children
+rung restack --dry-run
+rung restack --continue
+rung restack --abort
+```
+
+## Aliases
+
+- `rung re` — shorthand for `rung restack`
+
+## Options
+
+| Option               | Description                                    |
+| -------------------- | ---------------------------------------------- |
+| `--onto <branch>`    | New parent branch to rebase onto (required)    |
+| `--include-children` | Also rebase all descendant branches            |
+| `--dry-run`          | Show what would be done without making changes |
+| `--continue`         | Continue after resolving conflicts             |
+| `--abort`            | Abort and restore from backup                  |
+
+## How It Works
+
+When you run `rung restack --onto <new-parent>`:
+
+1. **Validate** — Checks that the move won't create a cycle in the stack
+2. **Backup** — Creates backup refs for affected branches
+3. **Rebase** — Rebases the branch onto the new parent: `git rebase --onto <new-parent> <old-parent> <branch>`
+4. **Update Stack** — Updates the stack topology with the new parent relationship
+5. **Report** — Shows what was restacked
+
+### Example
+
+Move a branch to a different parent:
+
+```bash
+$ rung restack --onto main
+✓ Restacked feat-add-api onto main (was: feat-add-model)
+```
+
+### Moving with Children
+
+To move a branch and all its descendants together:
+
+```bash
+$ rung restack feat-add-api --onto main --include-children
+✓ Restacked feat-add-api onto main
+✓ Restacked feat-add-api-tests onto feat-add-api
+```
+
+### Dry Run
+
+Preview changes without modifying anything:
+
+```bash
+$ rung restack --onto main --dry-run
+
+Would restack:
+  feat-add-api: rebase onto main (currently on feat-add-model)
+```
+
+## Handling Conflicts
+
+If a conflict occurs during restack, rung pauses and shows you what to do:
+
+```bash
+$ rung restack --onto main
+✗ Conflict while rebasing feat-add-api
+
+Conflict in: src/api/users.rs
+
+Resolve the conflict, then run:
+  rung restack --continue
+
+Or abort and restore:
+  rung restack --abort
+```
+
+### Resolving Conflicts
+
+1. Open the conflicting files and resolve the conflicts
+2. Stage the resolved files:
+   ```bash
+   git add src/api/users.rs
+   ```
+3. Continue the restack:
+   ```bash
+   rung restack --continue
+   ```
+
+### Aborting
+
+If you want to discard the partial restack and restore your branches:
+
+```bash
+rung restack --abort
+```
+
+This restores all affected branches to their pre-restack state using the backup refs.
+
+## Cycle Detection
+
+Rung prevents moves that would create circular dependencies in your stack:
+
+```bash
+$ rung restack feat-parent --onto feat-child
+Error: Cannot restack feat-parent onto feat-child: would create a cycle
+```
+
+A branch cannot be moved onto one of its own descendants.
+
+## Restack State
+
+During a restack operation, rung writes state to `.git/rung/restack_state.json`:
+
+```json
+{
+  "started_at": "2024-01-15T10:30:00Z",
+  "backup_id": "1704067200",
+  "target_branch": "feat-add-api",
+  "new_parent": "main",
+  "old_parent": "feat-add-model",
+  "original_branch": "feat-add-api",
+  "current_branch": "feat-add-api",
+  "completed": [],
+  "remaining": ["feat-add-api-tests"],
+  "stack_updated": false
+}
+```
+
+This allows `--continue` to resume from where it left off.
+
+## Notes
+
+- Always commit or stash your changes before restacking
+- The stack topology is updated after all rebases complete successfully
+- Backup refs are stored in `.git/rung/backups/` for undo capability
+- Use `--include-children` when you want to preserve the relative structure of descendant branches
+
+## Related Commands
+
+- [`sync`](/commands/sync/) — Rebase all branches when parents move
+- [`undo`](/commands/undo/) — Restore from last backup
+- [`status`](/commands/status/) — View stack topology


### PR DESCRIPTION
## Summary

Add documentation for the new `rung restack` command. Related to #78.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [ ] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Documentation
- **Current behavior**: No documentation for restack command
- **New behavior**: Full documentation across README, design docs, and Astro site
- **Breaking changes?**: No

## Other Information

Stacked on #83 (feat: add restack command)

**Files updated:**
- `README.md` - restack command section with usage examples
- `docs/design.md` - command table entry
- `site/src/content/docs/commands/restack.md` - full docs page
- `site/src/content/docs/commands/index.md` - command table + quick reference
- `site/astro.config.mjs` - sidebar navigation