### PR TITLE
refactor(cli): consolidate restack parameters into RestackOptions struct

### DIFF
--- a/crates/rung-cli/src/main.rs
+++ b/crates/rung-cli/src/main.rs
@@ -49,16 +49,19 @@ fn main() {
             abort,
             include_children,
             force,
-        } => commands::restack::run(
-            json,
-            branch.as_deref(),
-            onto.as_deref(),
-            dry_run,
-            continue_,
-            abort,
-            include_children,
-            force,
-        ),
+        } => {
+            let opts = commands::restack::RestackOptions {
+                json,
+                branch: branch.as_deref(),
+                onto: onto.as_deref(),
+                dry_run,
+                continue_,
+                abort,
+                include_children,
+                force,
+            };
+            commands::restack::run(&opts)
+        }
         Commands::Doctor => commands::doctor::run(json),
         Commands::Update { check } => commands::update::run(check),
         Commands::Completions { shell } => commands::completions::run(shell),


### PR DESCRIPTION
This PR addresses issue #89 by refactoring the restack::run() function to consolidate multiple parameters into a single RestackOptions struct.

**Changes:**
- Created RestackOptions struct to hold all restack command parameters
- Replaced individual function parameters with the struct
- Removed clippy allow attributes for fn_params_excessive_bools and too_many_arguments
- Updated main.rs to pass the struct to the run function

**Benefits:**
- Removes need for clippy suppressions
- Makes it easier to add new options without changing function signature
- Provides self-documenting parameter grouping
- Follows consistent CLI patterns
- Improves maintainability

The refactoring consolidates 8 boolean/option parameters into a single, well-structured options object, making the function cleaner and more extensible.

Fixes #89