### PR TITLE
feat(docs): add version badges to command pages

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -22,6 +22,7 @@ export default defineConfig({
       customCss: ["./src/styles/custom.css"],
       components: {
         SiteTitle: "./src/components/SiteTitle.astro",
+        PageTitle: "./src/components/PageTitle.astro",
       },
       sidebar: [
         {

--- a/site/src/components/PageTitle.astro
+++ b/site/src/components/PageTitle.astro
@@ -1,0 +1,51 @@
+---
+import type { Props } from "@astrojs/starlight/props";
+
+const PAGE_TITLE_ID = "_top";
+const { entry } = Astro.props;
+const entryData = entry.data as any;
+const since = entryData.since;
+---
+
+<div class="page-title-wrapper">
+  <h1 id={PAGE_TITLE_ID}>{entry.data.title}</h1>
+  {since && (
+    <span class:list={["version-badge", { unreleased: since === "unreleased" }]}>
+      {since === "unreleased" ? "unreleased" : `v${since}+`}
+    </span>
+  )}
+</div>
+
+<style>
+  .page-title-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-top: 1rem;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: var(--sl-text-h1);
+    line-height: var(--sl-line-height-headings);
+    font-weight: 600;
+    color: var(--sl-color-white);
+  }
+
+  .version-badge {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    border-radius: 4px;
+    background-color: var(--sl-color-accent);
+    color: var(--sl-color-black);
+  }
+
+  .version-badge.unreleased {
+    background-color: var(--sl-color-gray-5);
+    color: var(--sl-color-gray-2);
+    border: 1px dashed var(--sl-color-gray-4);
+  }
+</style>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,7 +1,16 @@
-import { defineCollection } from "astro:content";
+import { defineCollection, z } from "astro:content";
 import { docsLoader } from "@astrojs/starlight/loaders";
 import { docsSchema } from "@astrojs/starlight/schema";
 
 export const collections = {
-  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  docs: defineCollection({
+    loader: docsLoader(),
+    schema: docsSchema({
+      extend: z.object({
+        // Version when this feature was introduced
+        // Use "unreleased" for features not yet released
+        since: z.string().optional(),
+      }),
+    }),
+  }),
 };

--- a/site/src/content/docs/commands/absorb.md
+++ b/site/src/content/docs/commands/absorb.md
@@ -1,6 +1,7 @@
 ---
 title: absorb
 description: Absorb staged changes into the appropriate commits in your stack.
+since: "0.4.0"
 ---
 
 Absorb staged changes into the appropriate commits in your stack. This analyzes staged hunks and automatically creates fixup commits targeting the commits that last modified those lines.

--- a/site/src/content/docs/commands/adopt.md
+++ b/site/src/content/docs/commands/adopt.md
@@ -1,6 +1,7 @@
 ---
 title: adopt
 description: Bring an existing Git branch into the rung stack.
+since: "0.6.0"
 ---
 
 Adopt an existing Git branch into the rung stack by establishing its parent relationship. Use this when you have branches created outside of rung that you want to manage as part of your stack.

--- a/site/src/content/docs/commands/completions.md
+++ b/site/src/content/docs/commands/completions.md
@@ -1,6 +1,7 @@
 ---
 title: completions
 description: Generate shell completions for rung commands.
+since: "0.1.4"
 ---
 
 Generate shell completion scripts for tab-completion of rung commands and options.

--- a/site/src/content/docs/commands/create.md
+++ b/site/src/content/docs/commands/create.md
@@ -1,6 +1,7 @@
 ---
 title: create
 description: Create a new branch with the current branch as its parent.
+since: "0.1.0"
 ---
 
 Create a new branch in the stack with the current branch as its parent. This establishes the branch relationship that rung uses for syncing and PR management.

--- a/site/src/content/docs/commands/doctor.md
+++ b/site/src/content/docs/commands/doctor.md
@@ -1,6 +1,7 @@
 ---
 title: doctor
 description: Diagnose issues with the stack and repository.
+since: "0.1.0"
 ---
 
 Diagnose issues with your stack and repository. Checks for common problems and provides actionable suggestions.

--- a/site/src/content/docs/commands/init.md
+++ b/site/src/content/docs/commands/init.md
@@ -1,6 +1,7 @@
 ---
 title: init
 description: Initialize rung in a Git repository.
+since: "0.1.0"
 ---
 
 Initialize rung in the current Git repository. This creates the `.git/rung/` directory to store stack state.

--- a/site/src/content/docs/commands/log.md
+++ b/site/src/content/docs/commands/log.md
@@ -1,6 +1,7 @@
 ---
 title: log
 description: Show commits on the current branch between the parent branch and HEAD.
+since: "0.2.0"
 ---
 
 Show commits on the current branch—specifically, commits between the parent branch and HEAD. This helps you see exactly what changes are in the current stack branch, excluding commits from parent branches.

--- a/site/src/content/docs/commands/merge.md
+++ b/site/src/content/docs/commands/merge.md
@@ -1,6 +1,7 @@
 ---
 title: merge
 description: Merge the current branch's PR via GitHub API and update the stack.
+since: "0.1.0"
 ---
 
 Merge the current branch's pull request via the GitHub API. Automatically handles rebasing descendants and updating PR bases.

--- a/site/src/content/docs/commands/navigation.md
+++ b/site/src/content/docs/commands/navigation.md
@@ -1,6 +1,7 @@
 ---
 title: Navigation Commands
 description: Move between branches in your stack with nxt, prv, and move.
+since: "0.1.0"
 ---
 
 Rung provides several commands for navigating within your stack.

--- a/site/src/content/docs/commands/restack.md
+++ b/site/src/content/docs/commands/restack.md
@@ -1,6 +1,7 @@
 ---
 title: restack
 description: Move a branch to a different parent in the stack by rebasing it onto a new base.
+since: "0.4.0"
 ---
 
 Move a branch to a different parent in the stack. This is useful when you need to reorganize your stack topology—for example, moving a feature branch from one parent to another.

--- a/site/src/content/docs/commands/status.md
+++ b/site/src/content/docs/commands/status.md
@@ -1,6 +1,7 @@
 ---
 title: status
 description: Display the current stack as a tree view with sync state and PR status.
+since: "0.1.0"
 ---
 
 Display the current stack as a tree view showing branch relationships, sync state, and PR status.

--- a/site/src/content/docs/commands/submit.md
+++ b/site/src/content/docs/commands/submit.md
@@ -1,6 +1,7 @@
 ---
 title: submit
 description: Push all stack branches and create/update PRs on GitHub.
+since: "0.1.0"
 ---
 
 Push all stack branches and create or update pull requests on GitHub. Each PR includes a stack comment showing the branch hierarchy.

--- a/site/src/content/docs/commands/sync.md
+++ b/site/src/content/docs/commands/sync.md
@@ -1,6 +1,7 @@
 ---
 title: sync
 description: Sync the stack by rebasing all branches when the base moves forward.
+since: "0.1.0"
 ---
 
 Sync the stack by rebasing all branches when their parent branches have moved forward. This is the core command for keeping your stack up-to-date.

--- a/site/src/content/docs/commands/undo.md
+++ b/site/src/content/docs/commands/undo.md
@@ -1,6 +1,7 @@
 ---
 title: undo
 description: Undo the last sync operation, restoring all branches to their previous state.
+since: "0.1.0"
 ---
 
 Restore all branches to their state before the last sync operation.

--- a/site/src/content/docs/commands/update.md
+++ b/site/src/content/docs/commands/update.md
@@ -1,6 +1,7 @@
 ---
 title: update
 description: Update rung to the latest version.
+since: "0.1.2"
 ---
 
 Update rung to the latest version from crates.io.


### PR DESCRIPTION
## Summary

Add version availability badges to command documentation pages showing when each command was introduced.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Feature (docs)
- **Current behavior**: Command pages don't indicate version availability
- **New behavior**: Each command page shows a version badge (e.g., "v0.1.0+") next to the title
- **Breaking changes?**: No

## Other Information

Version mapping:
- v0.1.0: init, create, status, sync, submit, merge, navigation, doctor, undo
- v0.1.2: update
- v0.1.4: completions
- v0.2.0: log
- v0.4.0: absorb, restack
- v0.6.0: adopt