### PR TITLE
fix: allow both branch name and -m message in rung create

### DIFF
--- a/crates/rung-cli/src/commands/mod.rs
+++ b/crates/rung-cli/src/commands/mod.rs
@@ -82,6 +82,7 @@ pub enum Commands {
     #[command(group(
         clap::ArgGroup::new("create_input")
             .required(true)
+            .multiple(true)
             .args(["name", "message"])
     ))]
     Create {


### PR DESCRIPTION
Closes #103.

## Fix
Added `.multiple(true)` to the `create_input` ArgGroup in `crates/rung-cli/src/commands/mod.rs`. This allows users to specify both a branch name and a commit message simultaneously, as requested in the issue.

## Verification
Ran `rung create feat/auth -m "feat: add authentication"` locally and verified it no longer errors with conflict.