### PR TITLE
feat(status): implement --fetch flag and optimize doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ Display the current stack as a tree view with sync state and PR status.
 
 ```bash
 rung status              # Basic status
-rung status --fetch      # Fetch latest PR status from GitHub
+rung status --fetch      # Fetch from remote first for fresh divergence info
 rung status --json       # Output as JSON for tooling
 ```
 
 **Options:**
 
-- `--fetch` - Fetch latest PR status from GitHub
+- `--fetch` - Fetch latest remote state before showing status
 
 **Remote Divergence Indicators:**
 

--- a/crates/rung-cli/src/commands/doctor.rs
+++ b/crates/rung-cli/src/commands/doctor.rs
@@ -309,16 +309,16 @@ fn check_stack_integrity(repo: &Repository, stack: &rung_core::Stack, issues: &m
 }
 
 /// Check if a branch has a circular dependency.
-fn has_circular_dependency(
-    stack: &rung_core::Stack,
-    branch_name: &str,
-    visited: &mut Vec<String>,
+fn has_circular_dependency<'a>(
+    stack: &'a rung_core::Stack,
+    branch_name: &'a str,
+    visited: &mut Vec<&'a str>,
 ) -> bool {
-    if visited.contains(&branch_name.to_string()) {
+    if visited.contains(&branch_name) {
         return true;
     }
 
-    visited.push(branch_name.to_string());
+    visited.push(branch_name);
 
     if let Some(branch) = stack.find_branch(branch_name) {
         if let Some(parent) = &branch.parent {

--- a/crates/rung-cli/src/commands/mod.rs
+++ b/crates/rung-cli/src/commands/mod.rs
@@ -104,7 +104,7 @@ pub enum Commands {
     /// sync state and PR status.
     #[command(alias = "st")]
     Status {
-        /// Fetch latest PR status from GitHub.
+        /// Fetch latest remote state before showing status.
         #[arg(long)]
         fetch: bool,
     },

--- a/crates/rung-cli/src/commands/status.rs
+++ b/crates/rung-cli/src/commands/status.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use crate::output;
 
 /// Run the status command.
-pub fn run(json: bool, _fetch: bool) -> Result<()> {
+pub fn run(json: bool, fetch: bool) -> Result<()> {
     // Open repository
     let repo = Repository::open_current().context("Not inside a git repository")?;
 
@@ -19,6 +19,14 @@ pub fn run(json: bool, _fetch: bool) -> Result<()> {
     // Ensure initialized
     if !state.is_initialized() {
         bail!("Rung not initialized - run `rung init` first");
+    }
+
+    // Fetch latest from remote if requested
+    if fetch {
+        if !json {
+            output::info("Fetching from remote...");
+        }
+        repo.fetch_all().context("Failed to fetch from remote")?;
     }
 
     // Get current branch

--- a/crates/rung-core/src/stack.rs
+++ b/crates/rung-core/src/stack.rs
@@ -6,8 +6,6 @@ use serde::{Deserialize, Serialize};
 use crate::BranchName;
 
 /// A stack of dependent branches forming a PR chain.
-// TODO(long-term): For large stacks (>20 branches), consider adding a HashMap<String, usize>
-// index for O(1) lookup in find_branch() and find_branch_mut() instead of linear search.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Stack {
     /// Ordered list of branches from base to tip.

--- a/crates/rung-git/src/repository.rs
+++ b/crates/rung-git/src/repository.rs
@@ -730,6 +730,27 @@ impl Repository {
         }
     }
 
+    /// Fetch all remote tracking refs from origin.
+    ///
+    /// # Errors
+    /// Returns error if fetch fails.
+    pub fn fetch_all(&self) -> Result<()> {
+        let workdir = self.workdir().ok_or(Error::NotARepository)?;
+
+        let output = std::process::Command::new("git")
+            .args(["fetch", "origin", "--prune"])
+            .current_dir(workdir)
+            .output()
+            .map_err(|e| Error::FetchFailed(e.to_string()))?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            Err(Error::FetchFailed(stderr.to_string()))
+        }
+    }
+
     /// Fetch a branch from origin.
     ///
     /// # Errors

--- a/site/src/content/docs/commands/status.md
+++ b/site/src/content/docs/commands/status.md
@@ -10,6 +10,7 @@ Display the current stack as a tree view showing branch relationships, sync stat
 
 ```bash
 rung status
+rung status --fetch  # Fetch from remote first for fresh divergence info
 rung status --json
 ```
 
@@ -92,11 +93,19 @@ $ rung status --json
 | `conflict` | Rebase resulted in conflicts   |
 | `detached` | Orphaned (parent deleted)      |
 
+## Options
+
+| Option    | Description                                                                 |
+| --------- | --------------------------------------------------------------------------- |
+| `--fetch` | Run `git fetch` before showing status to get fresh remote divergence info   |
+| `--json`  | Output as JSON for tooling integration                                      |
+
 ## Notes
 
 - PR numbers are stored locally in `.git/rung/stack.json`
 - Use `--json` for CI/CD integration and scripting
 - The `is_current` field is only included when `true`
+- Remote divergence indicators are based on cached data; use `--fetch` for current state
 
 ## Related Commands
 


### PR DESCRIPTION
## Summary

Add `--fetch` flag to `rung status` and optimize doctor command performance.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Feature + Performance optimization
- **Current behavior**: `rung status` shows divergence based on cached remote refs; doctor allocates strings during cycle detection
- **New behavior**: `rung status --fetch` fetches from remote first for fresh divergence info; doctor uses `&str` refs to avoid allocations
- **Breaking changes?**: No

## Other Information

- Added `fetch_all()` method to `Repository` in rung-git
- Removed HashMap TODO from stack.rs (users won't have large stacks)
- Updated docs site and README