### PR TITLE
feat(core): add SplitState for split command

### DIFF
--- a/crates/rung-cli/src/services/test_mocks.rs
+++ b/crates/rung-cli/src/services/test_mocks.rs
@@ -439,4 +439,20 @@ impl StateStore for MockStateStore {
     fn cleanup_backups(&self, _keep: usize) -> CoreResult<()> {
         Ok(())
     }
+
+    fn is_split_in_progress(&self) -> bool {
+        false
+    }
+
+    fn load_split_state(&self) -> CoreResult<rung_core::state::SplitState> {
+        Err(rung_core::Error::NoBackupFound)
+    }
+
+    fn save_split_state(&self, _state: &rung_core::state::SplitState) -> CoreResult<()> {
+        Ok(())
+    }
+
+    fn clear_split_state(&self) -> CoreResult<()> {
+        Ok(())
+    }
 }

--- a/crates/rung-core/src/absorb.rs
+++ b/crates/rung-core/src/absorb.rs
@@ -513,6 +513,18 @@ mod tests {
         fn clear_restack_state(&self) -> crate::Result<()> {
             unimplemented!()
         }
+        fn is_split_in_progress(&self) -> bool {
+            false
+        }
+        fn load_split_state(&self) -> crate::Result<crate::state::SplitState> {
+            Err(crate::Error::NoBackupFound)
+        }
+        fn save_split_state(&self, _state: &crate::state::SplitState) -> crate::Result<()> {
+            Ok(())
+        }
+        fn clear_split_state(&self) -> crate::Result<()> {
+            Ok(())
+        }
         fn create_backup(&self, _branches: &[(&str, &str)]) -> crate::Result<String> {
             unimplemented!()
         }

--- a/crates/rung-core/src/lib.rs
+++ b/crates/rung-core/src/lib.rs
@@ -22,5 +22,5 @@ pub use branch_name::{BranchName, slugify};
 pub use config::Config;
 pub use error::{Error, Result};
 pub use stack::{BranchState, Stack, StackBranch};
-pub use state::{DivergenceRecord, RestackState, State, SyncState};
+pub use state::{DivergenceRecord, RestackState, SplitPoint, SplitState, State, SyncState};
 pub use traits::StateStore;

--- a/crates/rung-core/src/traits.rs
+++ b/crates/rung-core/src/traits.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use crate::Result;
 use crate::config::Config;
 use crate::stack::Stack;
-use crate::state::{RestackState, SyncState};
+use crate::state::{RestackState, SplitState, SyncState};
 
 /// Trait for state storage operations.
 ///
@@ -78,6 +78,20 @@ pub trait StateStore {
 
     /// Clear restack state (called when restack completes or aborts).
     fn clear_restack_state(&self) -> Result<()>;
+
+    // === Split State Operations ===
+
+    /// Check if a split is in progress.
+    fn is_split_in_progress(&self) -> bool;
+
+    /// Load the current split state.
+    fn load_split_state(&self) -> Result<SplitState>;
+
+    /// Save split state (called during split operation).
+    fn save_split_state(&self, state: &SplitState) -> Result<()>;
+
+    /// Clear split state (called when split completes or aborts).
+    fn clear_split_state(&self) -> Result<()>;
 
     // === Backup Operations ===
 


### PR DESCRIPTION
## Summary

Add core data structures for the `rung split` command (issue #97). This is Phase 1 of the split implementation.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes
- [ ] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Feature (new data structures)
- **Current behavior**: No split command exists
- **New behavior**: 
  - `SplitPoint` struct: tracks commit SHA, message, and target branch name for split points
  - `SplitState` struct: tracks split operation progress with backup/restore support
  - `StateStore` trait: extended with split state persistence methods
  - Mock implementations updated for trait compliance
- **Breaking changes?**: No

## Other Information

This is the first PR in a series to implement `rung split`. Next steps:
- Phase 2: CLI command scaffolding
- Phase 3: Interactive commit selection UI
- Phase 4: Split execution engine