### PR TITLE
fix(sync): handle manual rebase completion in continue

### DIFF
--- a/crates/rung-core/src/error.rs
+++ b/crates/rung-core/src/error.rs
@@ -57,6 +57,10 @@ pub enum Error {
     #[error("sync already in progress - run `rung sync --continue` or `rung sync --abort`")]
     SyncInProgress,
 
+    /// Sync operation failed.
+    #[error("sync failed: {0}")]
+    SyncFailed(String),
+
     /// State file parsing error.
     #[error("failed to parse {file}: {message}")]
     StateParseError { file: PathBuf, message: String },


### PR DESCRIPTION
## Summary

Handle the case where a user runs `git rebase --continue` manually instead of `rung sync --continue`. Fixes #119.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes
- [ ] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Bug fix
- **Current behavior**: `rung sync --continue` fails with "no rebase in progress" if user already ran `git rebase --continue` manually
- **New behavior**: Detects when no rebase is in progress and proceeds with remaining branches
- **Breaking changes?**: No

## Other Information

The fix uses the existing `is_rebasing()` method to check if a rebase is actually in progress before attempting to continue it.