### PR TITLE
feat: add install script for curl-pipe-sh installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,29 +24,22 @@ Rung helps you work with dependent branches by:
 
 ## Installation
 
-### Pre-built binaries (recommended)
-
-Download the latest release for your platform from [GitHub Releases](https://github.com/auswm85/rung/releases).
-
-**macOS (Apple Silicon):**
+### Quick install (recommended)
 
 ```bash
-curl -fsSL https://github.com/auswm85/rung/releases/latest/download/rung-$(curl -s https://api.github.com/repos/auswm85/rung/releases/latest | grep tag_name | cut -d '"' -f 4 | sed 's/v//')-aarch64-apple-darwin.tar.gz | tar xz
-sudo mv rung /usr/local/bin/
+curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh
 ```
 
-**macOS (Intel):**
+Install a specific version:
 
 ```bash
-curl -fsSL https://github.com/auswm85/rung/releases/latest/download/rung-$(curl -s https://api.github.com/repos/auswm85/rung/releases/latest | grep tag_name | cut -d '"' -f 4 | sed 's/v//')-x86_64-apple-darwin.tar.gz | tar xz
-sudo mv rung /usr/local/bin/
+curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh -s -- --version v0.8.0
 ```
 
-**Linux (x86_64):**
+Custom install directory:
 
 ```bash
-curl -fsSL https://github.com/auswm85/rung/releases/latest/download/rung-$(curl -s https://api.github.com/repos/auswm85/rung/releases/latest | grep tag_name | cut -d '"' -f 4 | sed 's/v//')-x86_64-unknown-linux-gnu.tar.gz | tar xz
-sudo mv rung /usr/local/bin/
+INSTALL_DIR=~/bin curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh
 ```
 
 **Windows:** Download the `.zip` from [releases](https://github.com/auswm85/rung/releases) and add to your PATH.

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ less install.sh  # review the script
 sh install.sh
 ```
 
-Install a specific version (uses matching install script from that release):
+Install a specific version:
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/auswm85/rung/v0.8.0/install.sh | sh
+curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh -s -- --version v0.8.0
 ```
 
 Custom install directory (defaults to `/usr/local/bin` or `~/.local/bin`):

--- a/README.md
+++ b/README.md
@@ -30,13 +30,21 @@ Rung helps you work with dependent branches by:
 curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh
 ```
 
-Install a specific version:
+Or review the script before running:
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh -s -- --version v0.8.0
+curl -sSfO https://raw.githubusercontent.com/auswm85/rung/main/install.sh
+less install.sh  # review the script
+sh install.sh
 ```
 
-Custom install directory:
+Install a specific version (uses matching install script from that release):
+
+```bash
+curl -sSf https://raw.githubusercontent.com/auswm85/rung/v0.8.0/install.sh | sh
+```
+
+Custom install directory (defaults to `/usr/local/bin` or `~/.local/bin`):
 
 ```bash
 INSTALL_DIR=~/bin curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,6 +41,7 @@ These improvements make Rung more pleasant to use and easier to contribute to:
 - [x] **Interactive navigation** (`rung move`) — TUI picker to jump to any branch in the stack
 - [x] **NO_COLOR support** ([#20](https://github.com/auswm85/rung/issues/20)) — Respect the `NO_COLOR` environment variable for accessibility and scripting
 - [x] **Color-coded PR status** ([#76](https://github.com/auswm85/rung/issues/76)) — Visual distinction between open, merged, and draft PRs in `rung status`
+- [x] **Install script** ([#113](https://github.com/auswm85/rung/issues/113)) — One-line installation via `curl | sh` with platform detection
 
 ### Security & Safety
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,266 @@
+#!/bin/sh
+# Rung installer script
+# Usage: curl -sSf https://rungstack.com/install.sh | sh
+#    or: curl -sSf https://rungstack.com/install.sh | sh -s -- --version v0.5.0
+#
+# Environment variables:
+#   INSTALL_DIR - Custom installation directory (default: /usr/local/bin or ~/.local/bin)
+
+set -e
+
+REPO="auswm85/rung"
+BINARY_NAME="rung"
+
+# Colors (only if terminal supports it)
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    BLUE='\033[0;34m'
+    BOLD='\033[1m'
+    NC='\033[0m' # No Color
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    BOLD=''
+    NC=''
+fi
+
+info() {
+    printf "${BLUE}info:${NC} %s\n" "$1"
+}
+
+warn() {
+    printf "${YELLOW}warning:${NC} %s\n" "$1"
+}
+
+error() {
+    printf "${RED}error:${NC} %s\n" "$1" >&2
+}
+
+success() {
+    printf "${GREEN}✓${NC} %s\n" "$1"
+}
+
+usage() {
+    cat <<EOF
+Rung installer
+
+Usage:
+    curl -sSf https://rungstack.com/install.sh | sh
+    curl -sSf https://rungstack.com/install.sh | sh -s -- [OPTIONS]
+
+Options:
+    --version <tag>    Install a specific version (e.g., v0.8.0)
+    --help             Show this help message
+
+Environment Variables:
+    INSTALL_DIR        Custom installation directory
+                       (default: /usr/local/bin if writable, else ~/.local/bin)
+
+Examples:
+    # Install latest version
+    curl -sSf https://rungstack.com/install.sh | sh
+
+    # Install specific version
+    curl -sSf https://rungstack.com/install.sh | sh -s -- --version v0.7.0
+
+    # Install to custom directory
+    INSTALL_DIR=~/bin curl -sSf https://rungstack.com/install.sh | sh
+EOF
+}
+
+detect_platform() {
+    OS=$(uname -s)
+    ARCH=$(uname -m)
+
+    case "$OS" in
+        Darwin)
+            OS_TYPE="apple-darwin"
+            ;;
+        Linux)
+            OS_TYPE="unknown-linux-gnu"
+            ;;
+        MINGW* | MSYS* | CYGWIN*)
+            error "Windows detected. Please download manually from:"
+            error "https://github.com/${REPO}/releases"
+            error "Or use: scoop install rung"
+            exit 1
+            ;;
+        *)
+            error "Unsupported operating system: $OS"
+            exit 1
+            ;;
+    esac
+
+    case "$ARCH" in
+        x86_64 | amd64)
+            ARCH_TYPE="x86_64"
+            ;;
+        arm64 | aarch64)
+            ARCH_TYPE="aarch64"
+            ;;
+        *)
+            error "Unsupported architecture: $ARCH"
+            exit 1
+            ;;
+    esac
+
+    # Linux currently only supports x86_64
+    if [ "$OS" = "Linux" ] && [ "$ARCH_TYPE" = "aarch64" ]; then
+        error "Linux ARM64 binaries are not currently available."
+        error "Please build from source: cargo install rung-cli"
+        exit 1
+    fi
+
+    TARGET="${ARCH_TYPE}-${OS_TYPE}"
+}
+
+get_latest_version() {
+    LATEST_URL="https://api.github.com/repos/${REPO}/releases/latest"
+
+    if command -v curl >/dev/null 2>&1; then
+        VERSION=$(curl -sSf "$LATEST_URL" | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+    elif command -v wget >/dev/null 2>&1; then
+        VERSION=$(wget -qO- "$LATEST_URL" | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+    else
+        error "Neither curl nor wget found. Please install one of them."
+        exit 1
+    fi
+
+    if [ -z "$VERSION" ]; then
+        error "Failed to fetch latest version from GitHub"
+        exit 1
+    fi
+}
+
+determine_install_dir() {
+    if [ -n "$INSTALL_DIR" ]; then
+        # User-specified directory
+        INSTALL_PATH="$INSTALL_DIR"
+    elif [ -w "/usr/local/bin" ]; then
+        # System directory if writable
+        INSTALL_PATH="/usr/local/bin"
+    else
+        # Fallback to user local bin
+        INSTALL_PATH="$HOME/.local/bin"
+    fi
+
+    # Create directory if it doesn't exist
+    if [ ! -d "$INSTALL_PATH" ]; then
+        info "Creating directory: $INSTALL_PATH"
+        mkdir -p "$INSTALL_PATH"
+    fi
+}
+
+download_and_install() {
+    VERSION_NUM=$(echo "$VERSION" | sed 's/^v//')
+    ARCHIVE_NAME="${BINARY_NAME}-${VERSION_NUM}-${TARGET}.tar.gz"
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE_NAME}"
+
+    info "Detected: ${TARGET}"
+    info "Downloading rung ${VERSION}..."
+
+    # Create temp directory
+    TMP_DIR=$(mktemp -d)
+    trap 'rm -rf "$TMP_DIR"' EXIT
+
+    # Download
+    if command -v curl >/dev/null 2>&1; then
+        HTTP_CODE=$(curl -sSL -w "%{http_code}" -o "$TMP_DIR/$ARCHIVE_NAME" "$DOWNLOAD_URL")
+        if [ "$HTTP_CODE" != "200" ]; then
+            error "Download failed (HTTP $HTTP_CODE)"
+            error "URL: $DOWNLOAD_URL"
+            if [ "$HTTP_CODE" = "404" ]; then
+                error "Version ${VERSION} may not exist or may not have a binary for ${TARGET}"
+            fi
+            exit 1
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        if ! wget -q -O "$TMP_DIR/$ARCHIVE_NAME" "$DOWNLOAD_URL"; then
+            error "Download failed"
+            error "URL: $DOWNLOAD_URL"
+            exit 1
+        fi
+    fi
+
+    # Extract
+    info "Extracting..."
+    tar -xzf "$TMP_DIR/$ARCHIVE_NAME" -C "$TMP_DIR"
+
+    # Find the binary (might be in a subdirectory)
+    BINARY_PATH=$(find "$TMP_DIR" -name "$BINARY_NAME" -type f | head -1)
+    if [ -z "$BINARY_PATH" ]; then
+        error "Binary not found in archive"
+        exit 1
+    fi
+
+    # Install
+    info "Installing to ${INSTALL_PATH}/${BINARY_NAME}..."
+
+    # Check if we need sudo
+    if [ -w "$INSTALL_PATH" ]; then
+        mv "$BINARY_PATH" "$INSTALL_PATH/$BINARY_NAME"
+        chmod +x "$INSTALL_PATH/$BINARY_NAME"
+    else
+        warn "Root permissions required to install to $INSTALL_PATH"
+        sudo mv "$BINARY_PATH" "$INSTALL_PATH/$BINARY_NAME"
+        sudo chmod +x "$INSTALL_PATH/$BINARY_NAME"
+    fi
+
+    success "rung ${VERSION} installed successfully!"
+    echo ""
+
+    # Check if install path is in PATH
+    case ":$PATH:" in
+        *":$INSTALL_PATH:"*)
+            printf "Run '${BOLD}rung --help${NC}' to get started.\n"
+            ;;
+        *)
+            warn "$INSTALL_PATH is not in your PATH"
+            echo ""
+            echo "Add it to your shell profile:"
+            echo "  export PATH=\"\$PATH:$INSTALL_PATH\""
+            ;;
+    esac
+}
+
+main() {
+    VERSION=""
+
+    # Parse arguments
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --version)
+                if [ -z "$2" ]; then
+                    error "--version requires a version argument (e.g., v0.8.0)"
+                    exit 1
+                fi
+                VERSION="$2"
+                shift 2
+                ;;
+            --help | -h)
+                usage
+                exit 0
+                ;;
+            *)
+                error "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
+    detect_platform
+
+    if [ -z "$VERSION" ]; then
+        get_latest_version
+    fi
+
+    determine_install_dir
+    download_and_install
+}
+
+main "$@"

--- a/site/src/content/docs/getting-started/installation.md
+++ b/site/src/content/docs/getting-started/installation.md
@@ -5,29 +5,28 @@ description: How to install rung on macOS, Linux, and Windows.
 
 Choose the installation method that works best for your system.
 
-## Pre-built Binaries (Recommended)
+## Quick Install (Recommended)
 
-Download the latest release for your platform from [GitHub Releases](https://github.com/auswm85/rung/releases).
-
-### macOS (Apple Silicon)
+The fastest way to install rung on macOS or Linux:
 
 ```bash
-curl -fsSL https://github.com/auswm85/rung/releases/latest/download/rung-$(curl -s https://api.github.com/repos/auswm85/rung/releases/latest | grep tag_name | cut -d '"' -f 4 | sed 's/v//')-aarch64-apple-darwin.tar.gz | tar xz
-sudo mv rung /usr/locxal/bin/
+curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh
 ```
 
-### macOS (Intel)
+This script automatically detects your platform and installs the latest version.
+
+### Options
+
+Install a specific version:
 
 ```bash
-curl -fsSL https://github.com/auswm85/rung/releases/latest/download/rung-$(curl -s https://api.github.com/repos/auswm85/rung/releases/latest | grep tag_name | cut -d '"' -f 4 | sed 's/v//')-x86_64-apple-darwin.tar.gz | tar xz
-sudo mv rung /usr/local/bin/
+curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh -s -- --version v0.8.0
 ```
 
-### Linux (x86_64)
+Custom install directory:
 
 ```bash
-curl -fsSL https://github.com/auswm85/rung/releases/latest/download/rung-$(curl -s https://api.github.com/repos/auswm85/rung/releases/latest | grep tag_name | cut -d '"' -f 4 | sed 's/v//')-x86_64-unknown-linux-gnu.tar.gz | tar xz
-sudo mv rung /usr/local/bin/
+INSTALL_DIR=~/bin curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh
 ```
 
 ### Windows

--- a/site/src/content/docs/getting-started/installation.md
+++ b/site/src/content/docs/getting-started/installation.md
@@ -17,13 +17,13 @@ This script automatically detects your platform and installs the latest version.
 
 ### Options
 
-Install a specific version:
+Install a specific version (uses matching install script from that release):
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh -s -- --version v0.8.0
+curl -sSf https://raw.githubusercontent.com/auswm85/rung/v0.8.0/install.sh | sh
 ```
 
-Custom install directory:
+Custom install directory (defaults to `/usr/local/bin` or `~/.local/bin`):
 
 ```bash
 INSTALL_DIR=~/bin curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh


### PR DESCRIPTION
## Summary

Add a shell script that enables one-line installation via `curl | sh`. Fixes #113.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Feature
- **Current behavior**: Installation requires multi-step commands or package managers
- **New behavior**: One-line install via `curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh`
- **Breaking changes?**: No

## Other Information

Features:
- Platform detection (macOS/Linux, x86_64/arm64)
- `--version` flag for specific versions
- `--help` flag for usage info
- `INSTALL_DIR` env var for custom install location
- Graceful error handling with helpful messages
- Colored output when terminal supports it