### PR TITLE
docs: host install script on docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,27 +27,13 @@ Rung helps you work with dependent branches by:
 ### Quick install (recommended)
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh
-```
-
-Or review the script before running:
-
-```bash
-curl -sSfO https://raw.githubusercontent.com/auswm85/rung/main/install.sh
-less install.sh  # review the script
-sh install.sh
-```
-
-Install a specific version:
-
-```bash
-curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh -s -- --version v0.8.0
+curl -sSf https://rungstack.com/install.sh | sh
 ```
 
 Custom install directory (defaults to `/usr/local/bin` or `~/.local/bin`):
 
 ```bash
-INSTALL_DIR=~/bin curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh
+INSTALL_DIR=~/bin curl -sSf https://rungstack.com/install.sh | sh
 ```
 
 **Windows:** Download the `.zip` from [releases](https://github.com/auswm85/rung/releases) and add to your PATH.

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Rung installer script
 # Usage: curl -sSf https://rungstack.com/install.sh | sh
-#    or: curl -sSf https://rungstack.com/install.sh | sh -s -- --version v0.5.0
 #
 # Environment variables:
 #   INSTALL_DIR - Custom installation directory (default: /usr/local/bin or ~/.local/bin)

--- a/site/src/content/docs/getting-started/installation.md
+++ b/site/src/content/docs/getting-started/installation.md
@@ -10,23 +10,17 @@ Choose the installation method that works best for your system.
 The fastest way to install rung on macOS or Linux:
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh
+curl -sSf https://rungstack.com/install.sh | sh
 ```
 
 This script automatically detects your platform and installs the latest version.
 
 ### Options
 
-Install a specific version (uses matching install script from that release):
-
-```bash
-curl -sSf https://raw.githubusercontent.com/auswm85/rung/v0.8.0/install.sh | sh
-```
-
 Custom install directory (defaults to `/usr/local/bin` or `~/.local/bin`):
 
 ```bash
-INSTALL_DIR=~/bin curl -sSf https://raw.githubusercontent.com/auswm85/rung/main/install.sh | sh
+INSTALL_DIR=~/bin curl -sSf https://rungstack.com/install.sh | sh
 ```
 
 ### Windows


### PR DESCRIPTION
## Summary

Move install script to docs site for better security and stability. Fixes install script hosting concerns.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [ ] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Documentation/Infrastructure
- **Current behavior**: Install script fetched from `main` branch (raw.githubusercontent.com)
- **New behavior**: Install script hosted on docs site (rungstack.com/install.sh)
- **Breaking changes?**: No

## Other Information

Changes:
- Move `install.sh` to `site/public/install.sh` (served at rungstack.com/install.sh)
- Delete root `install.sh`
- Update README and site docs to use rungstack.com URL
- Removes version-specific install examples (script auto-fetches latest release)

Security improvements:
- Script served from stable docs site, not `main` branch
- Cloudflare + GitHub Pages provides DDoS protection
- No exposure to unreleased code changes