### PR TITLE
refactor: rename GitHubApi trait to ForgeApi

### DIFF
--- a/crates/rung-cli/src/services/merge.rs
+++ b/crates/rung-cli/src/services/merge.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result, bail};
 use rung_core::stack::Stack;
 use rung_core::{BranchName, StateStore};
 use rung_git::{GitOps, Oid};
-use rung_github::{GitHubApi, MergeMethod, MergePullRequest, UpdatePullRequest};
+use rung_github::{ForgeApi, MergeMethod, MergePullRequest, UpdatePullRequest};
 
 /// Information about a descendant branch that was processed.
 #[derive(Debug, Clone)]
@@ -23,7 +23,7 @@ pub struct DescendantResult {
 }
 
 /// Service for merge operations with trait-based dependencies.
-pub struct MergeService<'a, G: GitOps, H: GitHubApi> {
+pub struct MergeService<'a, G: GitOps, H: ForgeApi> {
     repo: &'a G,
     client: &'a H,
     owner: String,
@@ -31,7 +31,7 @@ pub struct MergeService<'a, G: GitOps, H: GitHubApi> {
 }
 
 #[allow(clippy::future_not_send)]
-impl<'a, G: GitOps, H: GitHubApi> MergeService<'a, G, H> {
+impl<'a, G: GitOps, H: ForgeApi> MergeService<'a, G, H> {
     /// Create a new merge service.
     #[must_use]
     pub const fn new(repo: &'a G, client: &'a H, owner: String, repo_name: String) -> Self {
@@ -694,7 +694,7 @@ mod tests {
         use rung_git::Oid;
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        // Mock GitHubApi for merge testing
+        // Mock ForgeApi for merge testing
         struct MockGitHubClient {
             pr_mergeable: Option<bool>,
             merge_should_fail: bool,
@@ -740,7 +740,7 @@ mod tests {
             }
         }
 
-        impl rung_github::GitHubApi for MockGitHubClient {
+        impl rung_github::ForgeApi for MockGitHubClient {
             fn get_pr(
                 &self,
                 _owner: &str,

--- a/crates/rung-cli/src/services/submit.rs
+++ b/crates/rung-cli/src/services/submit.rs
@@ -9,7 +9,7 @@ use std::fmt::Write;
 use anyhow::{Context, Result, bail};
 use rung_core::stack::Stack;
 use rung_git::GitOps;
-use rung_github::{CreateComment, CreatePullRequest, GitHubApi, UpdateComment, UpdatePullRequest};
+use rung_github::{CreateComment, CreatePullRequest, ForgeApi, UpdateComment, UpdatePullRequest};
 use serde::Serialize;
 
 /// A planned action for a single branch.
@@ -110,7 +110,7 @@ pub struct SubmitConfig<'a> {
 pub struct SubmitService<'a, G, H>
 where
     G: GitOps,
-    H: GitHubApi,
+    H: ForgeApi,
 {
     git: &'a G,
     github: &'a H,
@@ -122,7 +122,7 @@ where
 impl<'a, G, H> SubmitService<'a, G, H>
 where
     G: GitOps,
-    H: GitHubApi,
+    H: ForgeApi,
 {
     /// Create a new submit service.
     pub const fn new(git: &'a G, github: &'a H, owner: String, repo: String) -> Self {
@@ -1067,7 +1067,7 @@ mod tests {
         use rung_core::stack::{Stack, StackBranch};
         use rung_git::Oid;
 
-        // Mock GitHubApi for submit testing
+        // Mock ForgeApi for submit testing
         struct MockGitHubClient {
             find_pr_result: Option<rung_github::PullRequest>,
         }
@@ -1086,7 +1086,7 @@ mod tests {
             }
         }
 
-        impl rung_github::GitHubApi for MockGitHubClient {
+        impl rung_github::ForgeApi for MockGitHubClient {
             fn get_pr(
                 &self,
                 _owner: &str,

--- a/crates/rung-cli/src/services/sync.rs
+++ b/crates/rung-cli/src/services/sync.rs
@@ -12,13 +12,13 @@ use rung_core::sync::{
     self, ExternalMergeInfo, ReconcileResult, ReparentedBranch, StaleBranches, SyncPlan, SyncResult,
 };
 use rung_git::GitOps;
-use rung_github::{GitHubApi, PullRequestState, UpdatePullRequest};
+use rung_github::{ForgeApi, PullRequestState, UpdatePullRequest};
 
 /// Threshold for switching from individual REST calls to batched GraphQL query.
 const BATCH_THRESHOLD: usize = 5;
 
 /// Service for sync operations with trait-based dependencies.
-pub struct SyncService<'a, G: GitOps, H: GitHubApi> {
+pub struct SyncService<'a, G: GitOps, H: ForgeApi> {
     repo: &'a G,
     client: &'a H,
     owner: String,
@@ -26,7 +26,7 @@ pub struct SyncService<'a, G: GitOps, H: GitHubApi> {
 }
 
 #[allow(clippy::future_not_send)]
-impl<'a, G: GitOps, H: GitHubApi> SyncService<'a, G, H> {
+impl<'a, G: GitOps, H: ForgeApi> SyncService<'a, G, H> {
     /// Create a new sync service.
     #[must_use]
     pub const fn new(repo: &'a G, client: &'a H, owner: String, repo_name: String) -> Self {
@@ -649,10 +649,10 @@ mod tests {
         use rung_core::stack::{Stack, StackBranch};
         use rung_git::Oid;
 
-        // Mock GitHubApi for testing
+        // Mock ForgeApi for testing
         struct MockGitHubClient;
 
-        impl rung_github::GitHubApi for MockGitHubClient {
+        impl rung_github::ForgeApi for MockGitHubClient {
             fn get_pr(
                 &self,
                 _owner: &str,
@@ -926,7 +926,7 @@ mod tests {
             }
         }
 
-        impl rung_github::GitHubApi for ConfigurableMockGitHubClient {
+        impl rung_github::ForgeApi for ConfigurableMockGitHubClient {
             fn get_pr(
                 &self,
                 _owner: &str,

--- a/crates/rung-git/src/traits.rs
+++ b/crates/rung-git/src/traits.rs
@@ -16,7 +16,7 @@ use crate::{BlameResult, ConflictPrediction, Hunk, RemoteDivergence, Result};
 /// - Mock implementations for testing
 /// - Alternative implementations (e.g., dry-run mode)
 ///
-/// Note: Unlike `GitHubApi`, git operations are synchronous since
+/// Note: Unlike `ForgeApi`, git operations are synchronous since
 /// git2 is a synchronous library.
 #[allow(clippy::missing_errors_doc)]
 pub trait GitOps {

--- a/crates/rung-github/src/client.rs
+++ b/crates/rung-github/src/client.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 
 use crate::auth::Auth;
 use crate::error::{Error, Result};
-use crate::traits::GitHubApi;
+use crate::traits::ForgeApi;
 use crate::types::{
     CheckRun, CreateComment, CreatePullRequest, IssueComment, MergePullRequest, MergeResult,
     PullRequest, PullRequestState, UpdateComment, UpdatePullRequest,
@@ -713,7 +713,7 @@ fn build_graphql_pr_query(numbers: &[u64]) -> String {
 
 // === Trait Implementation ===
 
-impl GitHubApi for GitHubClient {
+impl ForgeApi for GitHubClient {
     async fn get_pr(&self, owner: &str, repo: &str, number: u64) -> Result<PullRequest> {
         self.get_pr(owner, repo, number).await
     }

--- a/crates/rung-github/src/lib.rs
+++ b/crates/rung-github/src/lib.rs
@@ -6,7 +6,7 @@
 //! # Architecture
 //!
 //! The crate provides both a concrete [`GitHubClient`] implementation and
-//! a [`GitHubApi`] trait for dependency injection and testing.
+//! a [`ForgeApi`] trait for dependency injection and testing.
 //!
 //! # Security
 //!
@@ -22,7 +22,7 @@ mod types;
 pub use auth::Auth;
 pub use client::GitHubClient;
 pub use error::{Error, Result};
-pub use traits::GitHubApi;
+pub use traits::ForgeApi;
 // Re-export SecretString for constructing Auth::Token
 pub use secrecy::SecretString;
 pub use types::{

--- a/crates/rung-github/src/traits.rs
+++ b/crates/rung-github/src/traits.rs
@@ -1,7 +1,9 @@
-//! Trait abstractions for GitHub API operations.
+//! Trait abstractions for forge (code-hosting) API operations.
 //!
-//! This module defines the `GitHubApi` trait which abstracts GitHub API operations,
-//! enabling dependency injection and testability.
+//! This module defines the `ForgeApi` trait which abstracts the pull/merge
+//! request operations a forge backend must provide, enabling dependency
+//! injection, testability, and alternative backends. GitHub is currently the
+//! only implementation (see [`crate::GitHubClient`]).
 
 use std::collections::HashMap;
 
@@ -10,16 +12,16 @@ use crate::{
     PullRequest, Result, UpdateComment, UpdatePullRequest,
 };
 
-/// Trait for GitHub API operations.
+/// Trait for forge (code-hosting) API operations.
 ///
-/// This trait abstracts GitHub API calls, allowing for:
+/// This trait abstracts a forge backend's pull/merge request operations, allowing for:
 /// - Dependency injection in commands/services
 /// - Mock implementations for testing
-/// - Alternative implementations (e.g., offline mode, caching)
+/// - Alternative backends (e.g. GitLab, Bitbucket) and modes (offline, caching)
 ///
 /// All methods take `owner` and `repo` as parameters to support
 /// operations across different repositories.
-pub trait GitHubApi: Send + Sync {
+pub trait ForgeApi: Send + Sync {
     // === PR Operations ===
 
     /// Get a pull request by number.


### PR DESCRIPTION
## Summary

Rename the `GitHubApi` trait to `ForgeApi` and generalize its doc comments to forge-neutral language. This is the first slice of the forge abstraction (#156) that lays the groundwork for additional backends such as GitLab (#145). GitHub remains the only implementation — **no behavior change**.

Fixes #157. Part of #156.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes — _N/A: pure rename, existing suite (484 tests) covers behavior unchanged_
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — _N/A: no CLI changes_
- [x] **Documentation**: I have added doc comments (`///`) to new public functions — _generalized existing trait docs to forge-neutral wording_

## Change Description

- **Type of change**: Refactor (no behavior change)
- **Current behavior**: The PR-operations trait was named `GitHubApi`, with GitHub-specific doc comments. Services (`SyncService`, `MergeService`, `SubmitService`) are bound on it generically.
- **New behavior**: The trait is renamed to `ForgeApi` with forge-neutral docs, reflecting its role as the abstraction every forge backend implements. `GitHubClient` continues to be the sole implementation. All 23 references across `rung-github`, `rung-cli`, and `rung-git` updated.
- **Breaking changes?**: None for end users. The crate is pre-1.0 and the trait is only consumed within the workspace, so no back-compat alias is kept.

## Other Information

Follow-up slices tracked under #156:
- B (#158) — generalize remote detection (`ForgeKind`)
- C (#159) — forge factory + enum dispatch, drop hardcoded `GitHubClient`
- D (#160) — extract a `rung-forge` crate (optional)

Verified locally: `cargo build`, `cargo clippy --workspace`, `cargo fmt --check`, `cargo test --workspace` (484 passed, 0 failed).
