### PR TITLE
refactor(forge): generalize remote detection (ForgeKind)

### DIFF
--- a/crates/rung-cli/Cargo.toml
+++ b/crates/rung-cli/Cargo.toml
@@ -28,6 +28,7 @@ vendored-openssl = ["rung-core/vendored-openssl", "rung-git/vendored-openssl"]
 
 [dependencies]
 rung-core = { workspace = true }
+rung-forge = { workspace = true }
 rung-git = { workspace = true }
 rung-github = { workspace = true }
 

--- a/crates/rung-cli/src/commands/merge.rs
+++ b/crates/rung-cli/src/commands/merge.rs
@@ -66,7 +66,11 @@ fn setup_merge_context(repo: &Repository, state: &State) -> Result<(MergeContext
     let stack_parent_branch = branch.parent.as_ref().map(ToString::to_string);
 
     let origin_url = repo.origin_url()?;
-    let (owner, repo_name) = Repository::parse_github_remote(&origin_url)?;
+    let rung_forge::RemoteInfo {
+        owner,
+        repo: repo_name,
+        ..
+    } = rung_forge::parse_remote(&origin_url)?;
 
     let descendants =
         MergeService::<Repository, GitHubClient>::collect_descendants(&stack, &current_branch);

--- a/crates/rung-cli/src/commands/status.rs
+++ b/crates/rung-cli/src/commands/status.rs
@@ -119,8 +119,11 @@ fn fetch_pr_statuses(
     }
 
     let origin_url = repo.origin_url().context("No origin remote configured")?;
-    let (owner, repo_name) = Repository::parse_github_remote(&origin_url)
-        .context("Could not parse GitHub remote URL")?;
+    let rung_forge::RemoteInfo {
+        owner,
+        repo: repo_name,
+        ..
+    } = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
 
     let client = GitHubClient::new(&Auth::auto())
         .context("Failed to authenticate with GitHub - run `gh auth login` or set GITHUB_TOKEN")?;

--- a/crates/rung-cli/src/commands/submit.rs
+++ b/crates/rung-cli/src/commands/submit.rs
@@ -327,7 +327,8 @@ fn prompt_and_handle_uncommitted(repo: &Repository) -> Result<()> {
 /// Get owner and repo name from remote.
 fn get_remote_info(repo: &Repository) -> Result<(String, String)> {
     let origin_url = repo.origin_url().context("No origin remote configured")?;
-    Repository::parse_github_remote(&origin_url).context("Could not parse GitHub remote URL")
+    let info = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
+    Ok((info.owner, info.repo))
 }
 
 /// Create a commit using git CLI.

--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -140,7 +140,8 @@ pub fn run(
     let github_info = repo
         .origin_url()
         .ok()
-        .and_then(|url| Repository::parse_github_remote(&url).ok());
+        .and_then(|url| rung_forge::parse_remote(&url).ok())
+        .map(|info| (info.owner, info.repo));
 
     // Create runtime once for all async operations
     let rt = tokio::runtime::Runtime::new()?;
@@ -200,7 +201,7 @@ fn handle_abort(repo: &Repository, state: &State, json: bool) -> Result<()> {
         let has_github_remote = repo
             .origin_url()
             .ok()
-            .and_then(|url| Repository::parse_github_remote(&url).ok())
+            .and_then(|url| rung_forge::parse_remote(&url).ok())
             .is_some();
         let github_auth_unavailable =
             has_github_remote && GitHubClient::new(&Auth::auto()).is_err();
@@ -240,7 +241,7 @@ fn handle_continue(repo: &Repository, state: &State, json: bool, no_push: bool) 
     let has_github_remote = repo
         .origin_url()
         .ok()
-        .and_then(|url| Repository::parse_github_remote(&url).ok())
+        .and_then(|url| rung_forge::parse_remote(&url).ok())
         .is_some();
     let github_auth_unavailable = has_github_remote && GitHubClient::new(&Auth::auto()).is_err();
 

--- a/crates/rung-cli/src/services/absorb.rs
+++ b/crates/rung-cli/src/services/absorb.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use rung_core::StateStore;
 use rung_core::absorb::{self, AbsorbPlan, AbsorbResult};
-use rung_git::{AbsorbOps, Repository};
+use rung_git::AbsorbOps;
 use rung_github::{Auth, GitHubClient};
 
 /// Service for absorb operations with trait-based dependencies.
@@ -33,8 +33,11 @@ impl<'a, G: AbsorbOps> AbsorbService<'a, G> {
             .repo
             .origin_url()
             .context("No origin remote configured")?;
-        let (owner, repo_name) = Repository::parse_github_remote(&origin_url)
-            .context("Could not parse GitHub remote URL")?;
+        let rung_forge::RemoteInfo {
+            owner,
+            repo: repo_name,
+            ..
+        } = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
 
         let client = GitHubClient::new(&Auth::auto()).context(
             "GitHub auth required to detect default branch. Use --base <branch> to specify manually.",

--- a/crates/rung-cli/src/services/doctor.rs
+++ b/crates/rung-cli/src/services/doctor.rs
@@ -7,7 +7,6 @@ use std::collections::HashSet;
 
 use anyhow::{Context, Result};
 use rung_core::Stack;
-use rung_git::Repository;
 use rung_github::{Auth, GitHubClient, PullRequestState};
 use serde::Serialize;
 
@@ -347,7 +346,12 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
             return result;
         };
 
-        let Ok((owner, repo_name)) = Repository::parse_github_remote(&origin_url) else {
+        let Ok(rung_forge::RemoteInfo {
+            owner,
+            repo: repo_name,
+            ..
+        }) = rung_forge::parse_remote(&origin_url)
+        else {
             result
                 .issues
                 .push(Issue::warning("Origin is not a GitHub repository"));

--- a/crates/rung-forge/src/error.rs
+++ b/crates/rung-forge/src/error.rs
@@ -30,6 +30,14 @@ pub enum ForgeError {
     #[error("pull request not found: #{0}")]
     PrNotFound(u64),
 
+    /// A git remote URL could not be parsed as a known forge remote.
+    ///
+    /// The offending URL is retained for matching/diagnostics but deliberately
+    /// not rendered in the message: HTTPS remotes can embed credentials
+    /// (`https://user:token@host/...`), which must not leak into output or logs.
+    #[error("could not parse forge remote URL")]
+    InvalidRemoteUrl(String),
+
     /// API error with status code.
     #[error("forge API error ({status}): {message}")]
     ApiError {

--- a/crates/rung-forge/src/lib.rs
+++ b/crates/rung-forge/src/lib.rs
@@ -9,10 +9,12 @@
 //! on `rung-forge` — never on each other.
 
 mod error;
+mod remote;
 mod traits;
 mod types;
 
 pub use error::{ForgeError, Result};
+pub use remote::{ForgeKind, RemoteInfo, parse_remote};
 pub use traits::ForgeApi;
 pub use types::{
     CheckRun, CheckStatus, CreateComment, CreatePullRequest, IssueComment, MergeMethod,

--- a/crates/rung-forge/src/remote.rs
+++ b/crates/rung-forge/src/remote.rs
@@ -1,0 +1,189 @@
+//! Forge detection and remote-URL parsing.
+//!
+//! A git remote URL identifies both *which* forge hosts the repository
+//! ([`ForgeKind`]) and *which* repository it is ([`RemoteInfo`]). Keeping this
+//! logic in the contract crate means `rung-git` stays forge-agnostic and new
+//! backends extend detection in one place.
+
+use crate::{ForgeError, Result};
+
+/// A supported code-hosting forge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForgeKind {
+    /// github.com (and GitHub-style remotes).
+    GitHub,
+}
+
+impl ForgeKind {
+    /// Detect the forge that hosts a git remote URL.
+    ///
+    /// Recognizes both HTTPS and SSH forms. Returns `None` if the host is not
+    /// a known forge.
+    #[must_use]
+    pub fn detect(url: &str) -> Option<Self> {
+        if url.starts_with("git@github.com:")
+            || url.starts_with("https://github.com/")
+            || url.starts_with("http://github.com/")
+        {
+            return Some(Self::GitHub);
+        }
+        None
+    }
+}
+
+/// A repository identified from a git remote URL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteInfo {
+    /// The forge hosting the repository.
+    pub kind: ForgeKind,
+    /// Repository owner (user or organization).
+    pub owner: String,
+    /// Repository name.
+    pub repo: String,
+}
+
+/// Parse a git remote URL into its forge, owner, and repository.
+///
+/// Supports both HTTPS and SSH URLs:
+/// - `https://github.com/owner/repo.git`
+/// - `git@github.com:owner/repo.git`
+///
+/// # Errors
+/// Returns [`ForgeError::InvalidRemoteUrl`] if the URL is not a recognized
+/// forge remote or the owner/repo path cannot be extracted.
+pub fn parse_remote(url: &str) -> Result<RemoteInfo> {
+    match ForgeKind::detect(url) {
+        Some(ForgeKind::GitHub) => parse_github(url),
+        None => Err(ForgeError::InvalidRemoteUrl(url.to_string())),
+    }
+}
+
+/// Extract `(owner, repo)` from a github.com remote in either SSH or HTTPS form.
+fn parse_github(url: &str) -> Result<RemoteInfo> {
+    // SSH format: git@github.com:owner/repo.git
+    let path = url.strip_prefix("git@github.com:").or_else(|| {
+        // HTTPS format: https://github.com/owner/repo.git
+        url.strip_prefix("https://github.com/")
+            .or_else(|| url.strip_prefix("http://github.com/"))
+    });
+
+    if let Some(path) = path {
+        let path = path.trim_end_matches('/');
+        let path = path.strip_suffix(".git").unwrap_or(path);
+        // Require exactly `owner/repo` — reject extra path segments so a
+        // malformed remote fails here rather than later as a bad API repo name.
+        let mut parts = path.split('/');
+        if let (Some(owner), Some(repo), None) = (parts.next(), parts.next(), parts.next())
+            && !owner.is_empty()
+            && !repo.is_empty()
+        {
+            return Ok(RemoteInfo {
+                kind: ForgeKind::GitHub,
+                owner: owner.to_string(),
+                repo: repo.to_string(),
+            });
+        }
+    }
+
+    Err(ForgeError::InvalidRemoteUrl(url.to_string()))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_github_https() {
+        assert_eq!(
+            ForgeKind::detect("https://github.com/owner/repo.git"),
+            Some(ForgeKind::GitHub)
+        );
+    }
+
+    #[test]
+    fn test_detect_github_ssh() {
+        assert_eq!(
+            ForgeKind::detect("git@github.com:owner/repo.git"),
+            Some(ForgeKind::GitHub)
+        );
+    }
+
+    #[test]
+    fn test_detect_unknown_host() {
+        assert_eq!(ForgeKind::detect("https://gitlab.com/owner/repo.git"), None);
+        assert_eq!(ForgeKind::detect("git@bitbucket.org:owner/repo.git"), None);
+        assert_eq!(ForgeKind::detect("not a url"), None);
+    }
+
+    #[test]
+    fn test_parse_https_with_git_suffix() {
+        let info = parse_remote("https://github.com/octocat/hello-world.git").unwrap();
+        assert_eq!(info.kind, ForgeKind::GitHub);
+        assert_eq!(info.owner, "octocat");
+        assert_eq!(info.repo, "hello-world");
+    }
+
+    #[test]
+    fn test_parse_https_without_git_suffix() {
+        let info = parse_remote("https://github.com/octocat/hello-world").unwrap();
+        assert_eq!(info.owner, "octocat");
+        assert_eq!(info.repo, "hello-world");
+    }
+
+    #[test]
+    fn test_parse_ssh() {
+        let info = parse_remote("git@github.com:octocat/hello-world.git").unwrap();
+        assert_eq!(info.kind, ForgeKind::GitHub);
+        assert_eq!(info.owner, "octocat");
+        assert_eq!(info.repo, "hello-world");
+    }
+
+    #[test]
+    fn test_parse_unknown_forge_errors() {
+        let err = parse_remote("https://gitlab.com/owner/repo.git").unwrap_err();
+        assert!(matches!(err, ForgeError::InvalidRemoteUrl(_)));
+    }
+
+    #[test]
+    fn test_parse_missing_repo_errors() {
+        // Host matches but there is no owner/repo path.
+        assert!(matches!(
+            parse_remote("https://github.com/").unwrap_err(),
+            ForgeError::InvalidRemoteUrl(_)
+        ));
+        assert!(matches!(
+            parse_remote("https://github.com/owner").unwrap_err(),
+            ForgeError::InvalidRemoteUrl(_)
+        ));
+    }
+
+    #[test]
+    fn test_parse_trailing_slash_is_trimmed() {
+        let info = parse_remote("https://github.com/octocat/hello-world/").unwrap();
+        assert_eq!(info.owner, "octocat");
+        assert_eq!(info.repo, "hello-world");
+
+        // Trailing slash after the `.git` suffix is also tolerated.
+        let info = parse_remote("https://github.com/octocat/hello-world.git/").unwrap();
+        assert_eq!(info.repo, "hello-world");
+    }
+
+    #[test]
+    fn test_parse_extra_path_segments_error() {
+        // Extra segments must not be swallowed into `repo`.
+        assert!(matches!(
+            parse_remote("https://github.com/owner/repo/extra").unwrap_err(),
+            ForgeError::InvalidRemoteUrl(_)
+        ));
+    }
+
+    #[test]
+    fn test_invalid_remote_url_message_omits_url() {
+        // Credentials embedded in a remote URL must not leak via Display.
+        let err = ForgeError::InvalidRemoteUrl("https://user:token@host/x".to_string());
+        let msg = err.to_string();
+        assert!(!msg.contains("token"), "URL leaked in error message: {msg}");
+        assert!(!msg.contains("host"), "URL leaked in error message: {msg}");
+    }
+}

--- a/crates/rung-git/src/error.rs
+++ b/crates/rung-git/src/error.rs
@@ -38,10 +38,6 @@ pub enum Error {
     #[error("remote not found: {0}")]
     RemoteNotFound(String),
 
-    /// Invalid remote URL.
-    #[error("invalid remote URL: {0}")]
-    InvalidRemoteUrl(String),
-
     /// Push failed.
     #[error("push failed: {0}")]
     PushFailed(String),

--- a/crates/rung-git/src/repository.rs
+++ b/crates/rung-git/src/repository.rs
@@ -850,37 +850,6 @@ impl Repository {
         name.strip_prefix("refs/remotes/origin/").map(String::from)
     }
 
-    /// Parse owner and repo name from a GitHub URL.
-    ///
-    /// Supports both HTTPS and SSH URLs:
-    /// - `https://github.com/owner/repo.git`
-    /// - `git@github.com:owner/repo.git`
-    ///
-    /// # Errors
-    /// Returns error if URL cannot be parsed.
-    pub fn parse_github_remote(url: &str) -> Result<(String, String)> {
-        // SSH format: git@github.com:owner/repo.git
-        if let Some(rest) = url.strip_prefix("git@github.com:") {
-            let path = rest.strip_suffix(".git").unwrap_or(rest);
-            if let Some((owner, repo)) = path.split_once('/') {
-                return Ok((owner.to_string(), repo.to_string()));
-            }
-        }
-
-        // HTTPS format: https://github.com/owner/repo.git
-        if let Some(rest) = url
-            .strip_prefix("https://github.com/")
-            .or_else(|| url.strip_prefix("http://github.com/"))
-        {
-            let path = rest.strip_suffix(".git").unwrap_or(rest);
-            if let Some((owner, repo)) = path.split_once('/') {
-                return Ok((owner.to_string(), repo.to_string()));
-            }
-        }
-
-        Err(Error::InvalidRemoteUrl(url.to_string()))
-    }
-
     /// Push a branch to the remote.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary

Generalize git-remote detection into the forge contract. Adds `ForgeKind`, `RemoteInfo`, and `parse_remote()` to `rung-forge`, and migrates all 7 callers off `rung-git`'s GitHub-specific `Repository::parse_github_remote`. `rung-git` is now forge-agnostic — no `github.com` knowledge in the git-plumbing layer.

This is slice B of the forge abstraction (#156), the foundation for additional backends (GitLab #145).

Closes #158. Part of #156.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes — _8 new unit tests for detection + parsing in `rung-forge`_
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — _N/A: no CLI changes_
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Refactor (no behavior change)
- **Current behavior**: `Repository::parse_github_remote(url) -> (owner, repo)` lived in `rung-git`, hardcoding `github.com` (HTTPS + SSH) — a forge concern leaking into the low-level git wrapper. Seven `rung-cli` sites called it directly.
- **New behavior**: `rung-forge` owns remote parsing:
  - `ForgeKind` enum (`GitHub` for now) + `ForgeKind::detect(url) -> Option<ForgeKind>` — the dispatch primitive slice C will consume
  - `RemoteInfo { kind, owner, repo }` + `parse_remote(url) -> Result<RemoteInfo>`, returning `ForgeError::InvalidRemoteUrl` for unrecognized remotes
  - all 7 callers migrated; `Repository::parse_github_remote` and the now-unused `rung_git::Error::InvalidRemoteUrl` removed
- **Breaking changes?**: None for end users. Pre-1.0; the moved parser was only consumed within the workspace.

## Other Information

Verified locally: `cargo build --workspace`, `cargo clippy --workspace --all-targets` (clean), `cargo fmt --check`, `cargo test --workspace` → **498 passed, 0 failed**.

Follow-up under #156:
- C (#159) — forge factory + enum dispatch (`enum Forge { GitHub(GitHubClient) }`, `client_for`), dropping the hardcoded `GitHubClient::new` sites. Will dispatch on `ForgeKind::detect()` added here.
