### PR TITLE
refactor(forge): route clients through a Forge factory + enum dispatch

### DIFF
--- a/crates/rung-cli/src/commands/merge.rs
+++ b/crates/rung-cli/src/commands/merge.rs
@@ -6,7 +6,9 @@ use anyhow::{Context, Result, bail};
 use rung_core::State;
 use rung_core::stack::Stack;
 use rung_git::{Oid, Repository};
-use rung_github::{Auth, GitHubClient, MergeMethod};
+use rung_github::{Auth, MergeMethod};
+
+use crate::forge::Forge;
 use serde::Serialize;
 
 use crate::commands::utils;
@@ -73,7 +75,7 @@ fn setup_merge_context(repo: &Repository, state: &State) -> Result<(MergeContext
     } = rung_forge::parse_remote(&origin_url)?;
 
     let descendants =
-        MergeService::<Repository, GitHubClient>::collect_descendants(&stack, &current_branch);
+        MergeService::<Repository, Forge>::collect_descendants(&stack, &current_branch);
 
     // Capture old commits before any rebasing (needed for --onto)
     let mut old_commits: HashMap<String, Oid> = HashMap::new();
@@ -195,7 +197,8 @@ async fn execute_merge(
     json: bool,
 ) -> Result<(String, usize)> {
     let auth = Auth::auto();
-    let client = GitHubClient::new(&auth)?;
+    let origin_url = repo.origin_url()?;
+    let client = Forge::for_remote(&origin_url, &auth)?;
     let service = MergeService::new(repo, &client, ctx.owner.clone(), ctx.repo_name.clone());
 
     // Step 1: Validate PR is mergeable
@@ -291,7 +294,7 @@ fn print_child_relinks(stack: &Stack, ctx: &MergeContext, parent_branch: &str, j
 /// Rollback PR base changes on merge failure.
 #[allow(clippy::future_not_send)]
 async fn rollback_on_failure(
-    service: &MergeService<'_, Repository, GitHubClient>,
+    service: &MergeService<'_, Repository, Forge>,
     shifted_prs: &[(u64, String)],
     json: bool,
 ) {
@@ -323,7 +326,7 @@ async fn rollback_on_failure(
 /// Returns the count of successfully rebased descendants.
 #[allow(clippy::future_not_send)]
 async fn rebase_descendants_after_merge(
-    service: &MergeService<'_, Repository, GitHubClient>,
+    service: &MergeService<'_, Repository, Forge>,
     state: &State,
     stack: &Stack,
     ctx: &MergeContext,
@@ -384,7 +387,7 @@ async fn rebase_descendants_after_merge(
 /// Delete remote branch after merge.
 #[allow(clippy::future_not_send)]
 async fn delete_remote_branch(
-    service: &MergeService<'_, Repository, GitHubClient>,
+    service: &MergeService<'_, Repository, Forge>,
     branch: &str,
     json: bool,
 ) {
@@ -407,7 +410,7 @@ async fn delete_remote_branch(
 async fn update_stack_comments_after_merge(
     repo: &Repository,
     state: &State,
-    client: &GitHubClient,
+    client: &Forge,
     ctx: &MergeContext,
     json: bool,
 ) {

--- a/crates/rung-cli/src/commands/status.rs
+++ b/crates/rung-cli/src/commands/status.rs
@@ -6,7 +6,9 @@ use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use rung_core::State;
 use rung_git::Repository;
-use rung_github::{Auth, GitHubClient, PullRequestState};
+use rung_github::{Auth, ForgeApi, PullRequestState};
+
+use crate::forge::Forge;
 use serde::Serialize;
 
 use crate::output::{self, PrStatus};
@@ -125,8 +127,7 @@ fn fetch_pr_statuses(
         ..
     } = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
 
-    let client = GitHubClient::new(&Auth::auto())
-        .context("Failed to authenticate with GitHub - run `gh auth login` or set GITHUB_TOKEN")?;
+    let client = Forge::for_remote(&origin_url, &Auth::auto())?;
     let rt = tokio::runtime::Runtime::new()?;
 
     if !json {

--- a/crates/rung-cli/src/commands/submit.rs
+++ b/crates/rung-cli/src/commands/submit.rs
@@ -4,7 +4,9 @@ use anyhow::{Context, Result, bail};
 use inquire::{Select, Text};
 use rung_core::{State, stack::Stack, sync};
 use rung_git::{RemoteDivergence, Repository};
-use rung_github::{Auth, GitHubClient};
+use rung_github::Auth;
+
+use crate::forge::Forge;
 use serde::Serialize;
 
 use crate::commands::utils;
@@ -106,8 +108,8 @@ pub fn run(
 
     let (owner, repo_name) = get_remote_info(&repo)?;
 
-    let client = GitHubClient::new(&Auth::auto())
-        .context("Failed to authenticate with GitHub - run `gh auth login` or set GITHUB_TOKEN")?;
+    let origin_url = repo.origin_url().context("No origin remote configured")?;
+    let client = Forge::for_remote(&origin_url, &Auth::auto())?;
     let rt = tokio::runtime::Runtime::new()?;
 
     let service = SubmitService::new(&repo, &client, owner.clone(), repo_name.clone());

--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -13,8 +13,10 @@ use rung_core::sync::{
     self, ReconcileResult, SyncConflictPrediction, SyncResult, predict_sync_conflicts,
 };
 use rung_git::Repository;
-use rung_github::{Auth, GitHubClient};
+use rung_github::{Auth, ForgeApi};
 use serde::Serialize;
+
+use crate::forge::Forge;
 
 use crate::commands::utils;
 use crate::output;
@@ -33,7 +35,7 @@ struct SyncOutput {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     conflict_files: Vec<String>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
-    github_auth_unavailable: bool,
+    forge_auth_unavailable: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -54,7 +56,7 @@ struct DryRunOutput {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     branches_to_rebase: Vec<DryRunRebase>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
-    github_auth_unavailable: bool,
+    forge_auth_unavailable: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -136,18 +138,18 @@ pub fn run(
 
     repo.require_clean()?;
 
-    // Try to get GitHub remote info (optional - needed for PR operations)
-    let github_info = repo
-        .origin_url()
-        .ok()
-        .and_then(|url| rung_forge::parse_remote(&url).ok())
+    // Try to get the forge remote info (optional - needed for PR operations)
+    let origin_url = repo.origin_url().ok();
+    let forge_info = origin_url
+        .as_deref()
+        .and_then(|url| rung_forge::parse_remote(url).ok())
         .map(|info| (info.owner, info.repo));
 
     // Create runtime once for all async operations
     let rt = tokio::runtime::Runtime::new()?;
 
     // Determine base branch
-    let base_branch = determine_base_branch(base, github_info.as_ref(), &rt)?;
+    let base_branch = determine_base_branch(base, origin_url.as_deref(), &rt)?;
 
     // Fetch base branch (skip for --check to keep it side-effect free)
     if !check {
@@ -161,33 +163,44 @@ pub fn run(
         }
     }
 
-    // Create GitHub client (if available)
-    let mut github_auth_unavailable = false;
-    let client = github_info.as_ref().and_then(|_| {
-        GitHubClient::new(&Auth::auto())
+    // Create the forge client (if available)
+    let mut forge_auth_unavailable = false;
+    let client = match (forge_info.as_ref(), origin_url.as_deref()) {
+        (Some(_), Some(url)) => Forge::for_remote(url, &Auth::auto())
             .map_err(|_| {
-                github_auth_unavailable = true;
+                forge_auth_unavailable = true;
                 if !json {
                     output::warn("GitHub auth unavailable - skipping merge detection");
                 }
             })
-            .ok()
-    });
+            .ok(),
+        _ => None,
+    };
 
     // Run the main sync phases
     run_sync_phases(
         &repo,
         &state,
         &base_branch,
-        github_info.as_ref(),
+        forge_info.as_ref(),
         client.as_ref(),
         &rt,
         json,
         dry_run,
         check,
         no_push,
-        github_auth_unavailable,
+        forge_auth_unavailable,
     )
+}
+
+/// Whether a forge remote exists but its auth is unavailable.
+///
+/// Used to annotate `--json` output: `true` only when there is a recognized
+/// forge remote but a client for it cannot be constructed (auth failure).
+fn forge_auth_unavailable(repo: &Repository) -> bool {
+    repo.origin_url().ok().as_deref().is_some_and(|url| {
+        rung_forge::parse_remote(url).is_ok() && Forge::for_remote(url, &Auth::auto()).is_err()
+    })
 }
 
 /// Handle --abort flag.
@@ -197,22 +210,13 @@ fn handle_abort(repo: &Repository, state: &State, json: bool) -> Result<()> {
     }
     sync::abort_sync(repo, state)?;
     if json {
-        // Compute github_auth_unavailable consistently with handle_continue
-        let has_github_remote = repo
-            .origin_url()
-            .ok()
-            .and_then(|url| rung_forge::parse_remote(&url).ok())
-            .is_some();
-        let github_auth_unavailable =
-            has_github_remote && GitHubClient::new(&Auth::auto()).is_err();
-
         return output_json(&SyncOutput {
             status: SyncStatus::Aborted,
             branches_rebased: None,
             backup_id: None,
             conflict_branch: None,
             conflict_files: vec![],
-            github_auth_unavailable,
+            forge_auth_unavailable: forge_auth_unavailable(repo),
         });
     }
     output::success("Sync aborted - branches restored from backup");
@@ -236,37 +240,33 @@ fn handle_continue(repo: &Repository, state: &State, json: bool, no_push: bool) 
         push_stack_branches(repo, state, json)?;
     }
 
-    // Check GitHub auth availability for accurate JSON output
-    // Only flag as unavailable if there's a GitHub remote but auth fails
-    let has_github_remote = repo
-        .origin_url()
-        .ok()
-        .and_then(|url| rung_forge::parse_remote(&url).ok())
-        .is_some();
-    let github_auth_unavailable = has_github_remote && GitHubClient::new(&Auth::auto()).is_err();
-
-    handle_sync_result(result, json, github_auth_unavailable)
+    handle_sync_result(result, json, forge_auth_unavailable(repo))
 }
 
-/// Determine base branch from --base flag or GitHub API.
+/// Determine base branch from --base flag or the forge API.
 fn determine_base_branch(
     base: Option<&str>,
-    github_info: Option<&(String, String)>,
+    origin_url: Option<&str>,
     rt: &tokio::runtime::Runtime,
 ) -> Result<String> {
     if let Some(b) = base {
         return Ok(b.to_string());
     }
 
-    let (owner, repo_name) = github_info.ok_or_else(|| {
+    let url = origin_url.ok_or_else(|| {
         anyhow::anyhow!(
-            "Could not detect GitHub remote (no origin or non-GitHub URL). Use --base <branch> to specify manually."
+            "Could not detect forge remote (no origin or unsupported URL). Use --base <branch> to specify manually."
         )
     })?;
-    let client = GitHubClient::new(&Auth::auto()).context(
-        "GitHub auth required to detect default branch. Use --base <branch> to specify manually.",
+    let rung_forge::RemoteInfo { owner, repo, .. } = rung_forge::parse_remote(url).map_err(|_| {
+        anyhow::anyhow!(
+            "Could not detect forge remote (unsupported URL). Use --base <branch> to specify manually."
+        )
+    })?;
+    let client = Forge::for_remote(url, &Auth::auto()).context(
+        "Forge auth required to detect default branch. Use --base <branch> to specify manually.",
     )?;
-    rt.block_on(client.get_default_branch(owner, repo_name))
+    rt.block_on(client.get_default_branch(&owner, &repo))
         .context("Could not fetch default branch. Use --base <branch> to specify manually.")
 }
 
@@ -276,17 +276,17 @@ fn run_sync_phases(
     repo: &Repository,
     state: &State,
     base_branch: &str,
-    github_info: Option<&(String, String)>,
-    client: Option<&GitHubClient>,
+    forge_info: Option<&(String, String)>,
+    client: Option<&Forge>,
     rt: &tokio::runtime::Runtime,
     json: bool,
     dry_run: bool,
     check: bool,
     no_push: bool,
-    github_auth_unavailable: bool,
+    forge_auth_unavailable: bool,
 ) -> Result<()> {
     // Create SyncService once if GitHub is available
-    let service = match (client, github_info) {
+    let service = match (client, forge_info) {
         (Some(client), Some((owner, repo_name))) => Some(SyncService::new(
             repo,
             client,
@@ -333,7 +333,7 @@ fn run_sync_phases(
     // Load stack and check if empty
     let stack = state.load_stack()?;
     if stack.is_empty() {
-        return handle_empty_stack(json, github_auth_unavailable);
+        return handle_empty_stack(json, forge_auth_unavailable);
     }
 
     // Phase 3: Create sync plan
@@ -345,7 +345,7 @@ fn run_sync_phases(
 
     // Handle --dry-run mode
     if dry_run {
-        return print_dry_run(&plan, &reconcile_result, json, github_auth_unavailable);
+        return print_dry_run(&plan, &reconcile_result, json, forge_auth_unavailable);
     }
 
     // Execute sync
@@ -353,7 +353,7 @@ fn run_sync_phases(
 
     // If paused on conflict, return early
     if let SyncResult::Paused { .. } = &sync_result {
-        return handle_sync_result(sync_result, json, github_auth_unavailable);
+        return handle_sync_result(sync_result, json, forge_auth_unavailable);
     }
 
     // Phase 4 & 5: Update PR bases and push
@@ -367,12 +367,12 @@ fn run_sync_phases(
         no_push,
     )?;
 
-    handle_sync_result(sync_result, json, github_auth_unavailable)
+    handle_sync_result(sync_result, json, forge_auth_unavailable)
 }
 
 /// Phase 1: Detect merged PRs and reconcile stack.
 fn run_phase_detect_merged(
-    service: Option<&SyncService<'_, Repository, GitHubClient>>,
+    service: Option<&SyncService<'_, Repository, Forge>>,
     state: &State,
     base_branch: &str,
     rt: &tokio::runtime::Runtime,
@@ -393,7 +393,7 @@ fn run_phase_detect_merged(
 /// Phase 2: Remove stale branches from stack.
 fn run_phase_remove_stale(
     repo: &Repository,
-    service: Option<&SyncService<'_, Repository, GitHubClient>>,
+    service: Option<&SyncService<'_, Repository, Forge>>,
     state: &State,
     json: bool,
 ) -> Result<()> {
@@ -416,7 +416,7 @@ fn run_phase_remove_stale(
 }
 
 /// Handle empty stack case.
-fn handle_empty_stack(json: bool, github_auth_unavailable: bool) -> Result<()> {
+fn handle_empty_stack(json: bool, forge_auth_unavailable: bool) -> Result<()> {
     if json {
         return output_json(&SyncOutput {
             status: SyncStatus::AlreadySynced,
@@ -424,7 +424,7 @@ fn handle_empty_stack(json: bool, github_auth_unavailable: bool) -> Result<()> {
             backup_id: None,
             conflict_branch: None,
             conflict_files: vec![],
-            github_auth_unavailable,
+            forge_auth_unavailable,
         });
     }
     output::info("No branches in stack - nothing to sync");
@@ -434,7 +434,7 @@ fn handle_empty_stack(json: bool, github_auth_unavailable: bool) -> Result<()> {
 /// Execute the sync plan.
 fn execute_sync_plan(
     repo: &Repository,
-    service: Option<&SyncService<'_, Repository, GitHubClient>>,
+    service: Option<&SyncService<'_, Repository, Forge>>,
     state: &State,
     plan: &sync::SyncPlan,
     json: bool,
@@ -456,7 +456,7 @@ fn execute_sync_plan(
 
 /// Phase 4 & 5: Update PR bases on GitHub and push branches.
 fn run_phase_finalize(
-    service: Option<&SyncService<'_, Repository, GitHubClient>>,
+    service: Option<&SyncService<'_, Repository, Forge>>,
     state: &State,
     repo: &Repository,
     reconcile_result: &ReconcileResult,
@@ -485,7 +485,7 @@ fn run_phase_finalize(
 
 /// Push all stack branches to remote.
 fn push_branches(
-    service: Option<&SyncService<'_, Repository, GitHubClient>>,
+    service: Option<&SyncService<'_, Repository, Forge>>,
     state: &State,
     repo: &Repository,
     json: bool,
@@ -540,7 +540,7 @@ fn print_dry_run(
     plan: &rung_core::sync::SyncPlan,
     reconcile_result: &ReconcileResult,
     json: bool,
-    github_auth_unavailable: bool,
+    forge_auth_unavailable: bool,
 ) -> Result<()> {
     if json {
         let output = DryRunOutput {
@@ -562,7 +562,7 @@ fn print_dry_run(
                     new_base: action.new_base.clone(),
                 })
                 .collect(),
-            github_auth_unavailable,
+            forge_auth_unavailable,
         };
         println!("{}", serde_json::to_string_pretty(&output)?);
         return Ok(());
@@ -694,7 +694,7 @@ fn push_stack_branches(repo: &Repository, state: &State, json: bool) -> Result<(
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn handle_sync_result(result: SyncResult, json: bool, github_auth_unavailable: bool) -> Result<()> {
+fn handle_sync_result(result: SyncResult, json: bool, forge_auth_unavailable: bool) -> Result<()> {
     match result {
         SyncResult::AlreadySynced => {
             if json {
@@ -704,7 +704,7 @@ fn handle_sync_result(result: SyncResult, json: bool, github_auth_unavailable: b
                     backup_id: None,
                     conflict_branch: None,
                     conflict_files: vec![],
-                    github_auth_unavailable,
+                    forge_auth_unavailable,
                 });
             }
             output::success("Stack is already up-to-date");
@@ -720,7 +720,7 @@ fn handle_sync_result(result: SyncResult, json: bool, github_auth_unavailable: b
                     backup_id: Some(backup_id),
                     conflict_branch: None,
                     conflict_files: vec![],
-                    github_auth_unavailable,
+                    forge_auth_unavailable,
                 });
             }
             // Use char-safe truncation for backup_id display
@@ -741,7 +741,7 @@ fn handle_sync_result(result: SyncResult, json: bool, github_auth_unavailable: b
                     backup_id: Some(backup_id),
                     conflict_branch: Some(at_branch),
                     conflict_files,
-                    github_auth_unavailable,
+                    forge_auth_unavailable,
                 });
             }
             output::warn(&format!("Conflict in branch '{at_branch}'"));

--- a/crates/rung-cli/src/forge.rs
+++ b/crates/rung-cli/src/forge.rs
@@ -1,0 +1,199 @@
+//! Forge client dispatch.
+//!
+//! [`ForgeApi`] uses `impl Future` return types and is therefore not
+//! dyn-compatible. The [`Forge`] enum provides static dispatch across the
+//! supported forge backends, selected from a git remote URL via
+//! [`rung_forge::ForgeKind::detect`]. Adding a backend means adding a variant
+//! here — call sites stay backend-agnostic.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, anyhow};
+use rung_forge::{
+    CheckRun, CreateComment, CreatePullRequest, ForgeApi, ForgeKind, IssueComment,
+    MergePullRequest, MergeResult, PullRequest, Result as ForgeResult, UpdateComment,
+    UpdatePullRequest,
+};
+use rung_github::{Auth, GitHubClient};
+
+/// A forge client, statically dispatched by backend kind.
+pub enum Forge {
+    /// GitHub backend.
+    GitHub(GitHubClient),
+}
+
+impl Forge {
+    /// Build a forge client for a git remote, dispatching on the detected forge.
+    ///
+    /// # Errors
+    /// Returns an error if the remote is not a recognized forge, or if
+    /// authentication for the detected forge fails.
+    pub fn for_remote(remote_url: &str, auth: &Auth) -> Result<Self> {
+        match ForgeKind::detect(remote_url) {
+            Some(ForgeKind::GitHub) => {
+                let client = GitHubClient::new(auth).context(
+                    "Failed to authenticate with GitHub - run `gh auth login` or set GITHUB_TOKEN",
+                )?;
+                Ok(Self::GitHub(client))
+            }
+            None => Err(anyhow!(
+                "unsupported forge: remote is not a recognized GitHub repository"
+            )),
+        }
+    }
+}
+
+impl ForgeApi for Forge {
+    async fn get_pr(&self, owner: &str, repo: &str, number: u64) -> ForgeResult<PullRequest> {
+        match self {
+            Self::GitHub(c) => c.get_pr(owner, repo, number).await,
+        }
+    }
+
+    async fn get_prs_batch(
+        &self,
+        owner: &str,
+        repo: &str,
+        numbers: &[u64],
+    ) -> ForgeResult<HashMap<u64, PullRequest>> {
+        match self {
+            Self::GitHub(c) => c.get_prs_batch(owner, repo, numbers).await,
+        }
+    }
+
+    async fn find_pr_for_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+    ) -> ForgeResult<Option<PullRequest>> {
+        match self {
+            Self::GitHub(c) => c.find_pr_for_branch(owner, repo, branch).await,
+        }
+    }
+
+    async fn create_pr(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr: CreatePullRequest,
+    ) -> ForgeResult<PullRequest> {
+        match self {
+            Self::GitHub(c) => c.create_pr(owner, repo, pr).await,
+        }
+    }
+
+    async fn update_pr(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+        update: UpdatePullRequest,
+    ) -> ForgeResult<PullRequest> {
+        match self {
+            Self::GitHub(c) => c.update_pr(owner, repo, number, update).await,
+        }
+    }
+
+    async fn get_check_runs(
+        &self,
+        owner: &str,
+        repo: &str,
+        commit_sha: &str,
+    ) -> ForgeResult<Vec<CheckRun>> {
+        match self {
+            Self::GitHub(c) => c.get_check_runs(owner, repo, commit_sha).await,
+        }
+    }
+
+    async fn merge_pr(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+        merge: MergePullRequest,
+    ) -> ForgeResult<MergeResult> {
+        match self {
+            Self::GitHub(c) => c.merge_pr(owner, repo, number, merge).await,
+        }
+    }
+
+    async fn delete_ref(&self, owner: &str, repo: &str, ref_name: &str) -> ForgeResult<()> {
+        match self {
+            Self::GitHub(c) => c.delete_ref(owner, repo, ref_name).await,
+        }
+    }
+
+    async fn get_default_branch(&self, owner: &str, repo: &str) -> ForgeResult<String> {
+        match self {
+            Self::GitHub(c) => c.get_default_branch(owner, repo).await,
+        }
+    }
+
+    async fn list_pr_comments(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+    ) -> ForgeResult<Vec<IssueComment>> {
+        match self {
+            Self::GitHub(c) => c.list_pr_comments(owner, repo, pr_number).await,
+        }
+    }
+
+    async fn create_pr_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        comment: CreateComment,
+    ) -> ForgeResult<IssueComment> {
+        match self {
+            Self::GitHub(c) => c.create_pr_comment(owner, repo, pr_number, comment).await,
+        }
+    }
+
+    async fn update_pr_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+        comment: UpdateComment,
+    ) -> ForgeResult<IssueComment> {
+        match self {
+            Self::GitHub(c) => c.update_pr_comment(owner, repo, comment_id, comment).await,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use rung_github::SecretString;
+
+    fn test_auth() -> Auth {
+        Auth::Token(SecretString::from("test_token"))
+    }
+
+    #[test]
+    fn test_for_remote_github_https() {
+        let forge = Forge::for_remote("https://github.com/octocat/hello-world.git", &test_auth())
+            .expect("github remote should resolve");
+        assert!(matches!(forge, Forge::GitHub(_)));
+    }
+
+    #[test]
+    fn test_for_remote_github_ssh() {
+        let forge = Forge::for_remote("git@github.com:octocat/hello-world.git", &test_auth())
+            .expect("github ssh remote should resolve");
+        assert!(matches!(forge, Forge::GitHub(_)));
+    }
+
+    #[test]
+    fn test_for_remote_unsupported_forge_errors() {
+        // A recognizable-but-unsupported forge must not silently fall back to GitHub.
+        assert!(Forge::for_remote("https://gitlab.com/owner/repo.git", &test_auth()).is_err());
+        assert!(Forge::for_remote("not a url", &test_auth()).is_err());
+    }
+}

--- a/crates/rung-cli/src/main.rs
+++ b/crates/rung-cli/src/main.rs
@@ -3,6 +3,7 @@
 use clap::Parser;
 
 mod commands;
+mod forge;
 mod output;
 mod services;
 

--- a/crates/rung-cli/src/services/absorb.rs
+++ b/crates/rung-cli/src/services/absorb.rs
@@ -7,7 +7,9 @@ use anyhow::{Context, Result};
 use rung_core::StateStore;
 use rung_core::absorb::{self, AbsorbPlan, AbsorbResult};
 use rung_git::AbsorbOps;
-use rung_github::{Auth, GitHubClient};
+use rung_github::{Auth, ForgeApi};
+
+use crate::forge::Forge;
 
 /// Service for absorb operations with trait-based dependencies.
 pub struct AbsorbService<'a, G: AbsorbOps> {
@@ -39,7 +41,7 @@ impl<'a, G: AbsorbOps> AbsorbService<'a, G> {
             ..
         } = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
 
-        let client = GitHubClient::new(&Auth::auto()).context(
+        let client = Forge::for_remote(&origin_url, &Auth::auto()).context(
             "GitHub auth required to detect default branch. Use --base <branch> to specify manually.",
         )?;
         client

--- a/crates/rung-cli/src/services/doctor.rs
+++ b/crates/rung-cli/src/services/doctor.rs
@@ -7,7 +7,9 @@ use std::collections::HashSet;
 
 use anyhow::{Context, Result};
 use rung_core::Stack;
-use rung_github::{Auth, GitHubClient, PullRequestState};
+use rung_github::{Auth, ForgeApi, PullRequestState};
+
+use crate::forge::Forge;
 use serde::Serialize;
 
 /// Diagnostic issue severity.
@@ -328,17 +330,8 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
     pub async fn check_github(&self) -> CheckResult {
         let mut result = CheckResult::default();
 
-        // Check auth
-        let auth = Auth::auto();
-        let Ok(client) = GitHubClient::new(&auth) else {
-            result.issues.push(
-                Issue::error("GitHub authentication failed")
-                    .with_suggestion("Set GITHUB_TOKEN or authenticate with `gh auth login`"),
-            );
-            return result;
-        };
-
-        // Get repo info
+        // Resolve the remote first so non-forge remotes are reported before any
+        // forge API call (the forge kind gates which backend we talk to).
         let Ok(origin_url) = self.repo.origin_url() else {
             result
                 .issues
@@ -355,6 +348,16 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
             result
                 .issues
                 .push(Issue::warning("Origin is not a GitHub repository"));
+            return result;
+        };
+
+        // Authenticate with the detected forge.
+        let auth = Auth::auto();
+        let Ok(client) = Forge::for_remote(&origin_url, &auth) else {
+            result.issues.push(
+                Issue::error("GitHub authentication failed")
+                    .with_suggestion("Set GITHUB_TOKEN or authenticate with `gh auth login`"),
+            );
             return result;
         };
 


### PR DESCRIPTION
## Summary

Introduce a `Forge` client that dispatches `ForgeApi` calls to backend implementations, and route all of rung-cli through a `Forge::for_remote(url, auth)` factory instead of constructing `GitHubClient` directly. This is the final slice of the forge abstraction (#156): backend selection now happens in one place, keyed off `ForgeKind::detect()`.

Closes #159. Part of #156.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes — _3 tests for the `Forge::for_remote` factory (GitHub https/ssh resolve, unsupported forge errors)_
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — _N/A: no CLI surface changes_
- [x] **Documentation**: I have added doc comments (`///`) to new public items

## Change Description

- **Type of change**: Refactor (with one intentional behavior change, noted below)
- **Current behavior**: Every command constructed a concrete `rung_github::GitHubClient` directly (8 sites), and services were generic over `GitHubClient`. Adding a backend would have meant touching every call site.
- **New behavior**:
  - New `crates/rung-cli/src/forge.rs`: `enum Forge { GitHub(GitHubClient) }` implementing `ForgeApi` via static enum dispatch (the trait uses `impl Future` returns and is not dyn-compatible), plus `Forge::for_remote(remote_url, auth)` which dispatches on `ForgeKind::detect()` and errors on unsupported remotes.
  - All 8 production `GitHubClient::new(...)` sites now go through `Forge::for_remote(...)`; `GitHubClient` remains only in test mocks.
  - Services (`SyncService`/`MergeService`/`SubmitService`) are parameterized over `Forge`.
  - `doctor` now resolves the remote (kind detection) **before** authenticating, so a non-forge/non-GitHub remote is reported before any forge API call (addresses a prior review comment about gating on forge kind).
  - Generalized leftover identifiers: `github_info` → `forge_info`; the `github_auth_unavailable` field (and its JSON key in `rung sync --json`) → `forge_auth_unavailable`. User-facing "GitHub" strings kept while GitHub is the only backend.
- **Breaking changes?**:
  - `rung sync --json`: the `github_auth_unavailable` key is renamed to `forge_auth_unavailable`. No in-repo consumer depends on it (the VS Code extension reads `status`/`doctor --json` only).
  - `rung doctor`: a repo with no origin (or a non-GitHub remote) **and** missing auth is now reported as a warning ("No origin remote configured" / "Origin is not a GitHub repository") rather than an "GitHub authentication failed" error. This is more accurate (the real issue is the remote, not auth), but it changes doctor's error count for those cases.

## Other Information

Verified locally: `cargo build --workspace`, `cargo clippy --workspace --all-targets` (clean), `cargo fmt --check`, `cargo test --workspace` → **504 passed, 0 failed**.

A `/code-review high` pass on this branch was applied: deduplicated the `forge_auth_unavailable` probe into a helper, and removed a dead unreachable error branch in `determine_base_branch`.

With this merged, the forge abstraction (#156) is complete. Forward-looking cleanup deferred to when a second backend lands: make the remaining user-facing "GitHub" strings per-`ForgeKind`.
