### PR TITLE
chore: release v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/auswm85/rung"
@@ -11,10 +11,10 @@ rust-version = "1.88"
 
 [workspace.dependencies]
 # Internal crates
-rung-core = { version = "0.8.0", path = "crates/rung-core" }
-rung-forge = { version = "0.8.0", path = "crates/rung-forge" }
-rung-git = { version = "0.8.0", path = "crates/rung-git" }
-rung-github = { version = "0.8.0", path = "crates/rung-github" }
+rung-core = { version = "0.9.0", path = "crates/rung-core" }
+rung-forge = { version = "0.9.0", path = "crates/rung-forge" }
+rung-git = { version = "0.9.0", path = "crates/rung-git" }
+rung-github = { version = "0.9.0", path = "crates/rung-github" }
 
 # Git operations
 git2 = "0.19"


### PR DESCRIPTION
## Summary

Release prep for **v0.9.0**: bump the workspace version `0.8.0 → 0.9.0` (workspace.package + the four internal `rung-*` dependency pins). No code changes.

Merging this, then tagging `v0.9.0`, triggers `release.yml` (binaries + GitHub release + crates.io publish for all five crates).

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes — _N/A: version bump only_
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — _N/A_
- [x] **Documentation**: I have added doc comments (`///`) to new public functions — _N/A_

## Change Description

- **Type of change**: Release / chore
- **Current behavior**: Workspace at `0.8.0`.
- **New behavior**: Workspace at `0.9.0`; all five crates report `0.9.0`. `cargo build --workspace` clean.
- **Breaking changes?**: None introduced by this PR. The 0.9.0 release itself carries two intentional CLI breaks (documented in the release notes):
  - `rung sync --json`: `github_auth_unavailable` → `forge_auth_unavailable`
  - `rung doctor`: no-origin / non-GitHub repo with missing auth now reports a warning rather than an error

## Other Information

0.9.0 headline is the **forge abstraction** (#161–#164, closing #156). Post-merge release steps: tag `v0.9.0` → CI publishes; then update `Formula/rung.rb` (url + sha256) and finalize the release notes.
