### PR TITLE
feat(forge): introduce forge-neutral RepoId

### DIFF
--- a/crates/rung-cli/src/commands/merge.rs
+++ b/crates/rung-cli/src/commands/merge.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, bail};
 use rung_core::State;
 use rung_core::stack::Stack;
 use rung_git::{Oid, Repository};
-use rung_github::{Auth, MergeMethod};
+use rung_github::{Auth, MergeMethod, RepoId};
 
 use crate::forge::Forge;
 use serde::Serialize;
@@ -31,8 +31,7 @@ struct MergeContext {
     current_branch: String,
     pr_number: u64,
     stack_parent_branch: Option<String>,
-    owner: String,
-    repo_name: String,
+    repo_id: RepoId,
     descendants: Vec<String>,
     old_commits: HashMap<String, Oid>,
 }
@@ -68,11 +67,7 @@ fn setup_merge_context(repo: &Repository, state: &State) -> Result<(MergeContext
     let stack_parent_branch = branch.parent.as_ref().map(ToString::to_string);
 
     let origin_url = repo.origin_url()?;
-    let rung_forge::RemoteInfo {
-        owner,
-        repo: repo_name,
-        ..
-    } = rung_forge::parse_remote(&origin_url)?;
+    let rung_forge::RemoteInfo { repo: repo_id, .. } = rung_forge::parse_remote(&origin_url)?;
 
     let descendants =
         MergeService::<Repository, Forge>::collect_descendants(&stack, &current_branch);
@@ -89,8 +84,7 @@ fn setup_merge_context(repo: &Repository, state: &State) -> Result<(MergeContext
             current_branch,
             pr_number,
             stack_parent_branch,
-            owner,
-            repo_name,
+            repo_id,
             descendants,
             old_commits,
         },
@@ -199,7 +193,7 @@ async fn execute_merge(
     let auth = Auth::auto();
     let origin_url = repo.origin_url()?;
     let client = Forge::for_remote(&origin_url, &auth)?;
-    let service = MergeService::new(repo, &client, ctx.owner.clone(), ctx.repo_name.clone());
+    let service = MergeService::new(repo, &client, ctx.repo_id.clone());
 
     // Step 1: Validate PR is mergeable
     let pr = service.validate_mergeable(ctx.pr_number).await?;
@@ -436,7 +430,7 @@ async fn update_stack_comments_after_merge(
         }
     };
 
-    let submit_service = SubmitService::new(repo, client, ctx.owner.clone(), ctx.repo_name.clone());
+    let submit_service = SubmitService::new(repo, client, ctx.repo_id.clone());
 
     if let Err(e) = submit_service
         .update_stack_comments(&stack, &default_branch)

--- a/crates/rung-cli/src/commands/status.rs
+++ b/crates/rung-cli/src/commands/status.rs
@@ -121,11 +121,8 @@ fn fetch_pr_statuses(
     }
 
     let origin_url = repo.origin_url().context("No origin remote configured")?;
-    let rung_forge::RemoteInfo {
-        owner,
-        repo: repo_name,
-        ..
-    } = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
+    let rung_forge::RemoteInfo { repo: repo_id, .. } =
+        rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
 
     let client = Forge::for_remote(&origin_url, &Auth::auto())?;
     let rt = tokio::runtime::Runtime::new()?;
@@ -137,7 +134,7 @@ fn fetch_pr_statuses(
             pr_numbers.len(),
         ));
     }
-    *pr_cache = rt.block_on(client.get_prs_batch(&owner, &repo_name, &pr_numbers))?;
+    *pr_cache = rt.block_on(client.get_prs_batch(&repo_id, &pr_numbers))?;
     Ok(())
 }
 

--- a/crates/rung-cli/src/commands/submit.rs
+++ b/crates/rung-cli/src/commands/submit.rs
@@ -106,13 +106,13 @@ pub fn run(
             .context("Failed to load default branch from config")?,
     };
 
-    let (owner, repo_name) = get_remote_info(&repo)?;
+    let repo_id = get_remote_info(&repo)?;
 
     let origin_url = repo.origin_url().context("No origin remote configured")?;
     let client = Forge::for_remote(&origin_url, &Auth::auto())?;
     let rt = tokio::runtime::Runtime::new()?;
 
-    let service = SubmitService::new(&repo, &client, owner.clone(), repo_name.clone());
+    let service = SubmitService::new(&repo, &client, repo_id.clone());
 
     // Phase 0: Sync Protection
     if !force {
@@ -129,7 +129,7 @@ pub fn run(
 
     // Phase 2: Execute the plan (mutations only)
     if !json {
-        output::info(&format!("Submitting to {owner}/{repo_name}..."));
+        output::info(&format!("Submitting to {repo_id}..."));
     }
 
     // Warn about diverged branches before pushing
@@ -326,11 +326,11 @@ fn prompt_and_handle_uncommitted(repo: &Repository) -> Result<()> {
     Ok(())
 }
 
-/// Get owner and repo name from remote.
-fn get_remote_info(repo: &Repository) -> Result<(String, String)> {
+/// Get the forge-neutral repository identifier from the origin remote.
+fn get_remote_info(repo: &Repository) -> Result<rung_forge::RepoId> {
     let origin_url = repo.origin_url().context("No origin remote configured")?;
     let info = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
-    Ok((info.owner, info.repo))
+    Ok(info.repo)
 }
 
 /// Create a commit using git CLI.

--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -13,7 +13,7 @@ use rung_core::sync::{
     self, ReconcileResult, SyncConflictPrediction, SyncResult, predict_sync_conflicts,
 };
 use rung_git::Repository;
-use rung_github::{Auth, ForgeApi};
+use rung_github::{Auth, ForgeApi, RepoId};
 use serde::Serialize;
 
 use crate::forge::Forge;
@@ -143,7 +143,7 @@ pub fn run(
     let forge_info = origin_url
         .as_deref()
         .and_then(|url| rung_forge::parse_remote(url).ok())
-        .map(|info| (info.owner, info.repo));
+        .map(|info| info.repo);
 
     // Create runtime once for all async operations
     let rt = tokio::runtime::Runtime::new()?;
@@ -258,15 +258,16 @@ fn determine_base_branch(
             "Could not detect forge remote (no origin or unsupported URL). Use --base <branch> to specify manually."
         )
     })?;
-    let rung_forge::RemoteInfo { owner, repo, .. } = rung_forge::parse_remote(url).map_err(|_| {
-        anyhow::anyhow!(
-            "Could not detect forge remote (unsupported URL). Use --base <branch> to specify manually."
-        )
-    })?;
+    let rung_forge::RemoteInfo { repo: repo_id, .. } =
+        rung_forge::parse_remote(url).map_err(|_| {
+            anyhow::anyhow!(
+                "Could not detect forge remote (unsupported URL). Use --base <branch> to specify manually."
+            )
+        })?;
     let client = Forge::for_remote(url, &Auth::auto()).context(
         "Forge auth required to detect default branch. Use --base <branch> to specify manually.",
     )?;
-    rt.block_on(client.get_default_branch(&owner, &repo))
+    rt.block_on(client.get_default_branch(&repo_id))
         .context("Could not fetch default branch. Use --base <branch> to specify manually.")
 }
 
@@ -276,7 +277,7 @@ fn run_sync_phases(
     repo: &Repository,
     state: &State,
     base_branch: &str,
-    forge_info: Option<&(String, String)>,
+    forge_info: Option<&RepoId>,
     client: Option<&Forge>,
     rt: &tokio::runtime::Runtime,
     json: bool,
@@ -287,12 +288,7 @@ fn run_sync_phases(
 ) -> Result<()> {
     // Create SyncService once if GitHub is available
     let service = match (client, forge_info) {
-        (Some(client), Some((owner, repo_name))) => Some(SyncService::new(
-            repo,
-            client,
-            owner.clone(),
-            repo_name.clone(),
-        )),
+        (Some(client), Some(repo_id)) => Some(SyncService::new(repo, client, repo_id.clone())),
         _ => None,
     };
 

--- a/crates/rung-cli/src/forge.rs
+++ b/crates/rung-cli/src/forge.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use anyhow::{Context, Result, anyhow};
 use rung_forge::{
     CheckRun, CreateComment, CreatePullRequest, ForgeApi, ForgeKind, IssueComment,
-    MergePullRequest, MergeResult, PullRequest, Result as ForgeResult, UpdateComment,
+    MergePullRequest, MergeResult, PullRequest, RepoId, Result as ForgeResult, UpdateComment,
     UpdatePullRequest,
 };
 use rung_github::{Auth, GitHubClient};
@@ -43,125 +43,111 @@ impl Forge {
     }
 }
 
+// `GitHubClient` has inherent `(owner, repo, …)` methods that shadow the
+// trait's `(&RepoId, …)` methods under normal method-call resolution, so each
+// arm dispatches through `ForgeApi` explicitly to reach the trait impl.
 impl ForgeApi for Forge {
-    async fn get_pr(&self, owner: &str, repo: &str, number: u64) -> ForgeResult<PullRequest> {
+    async fn get_pr(&self, repo: &RepoId, number: u64) -> ForgeResult<PullRequest> {
         match self {
-            Self::GitHub(c) => c.get_pr(owner, repo, number).await,
+            Self::GitHub(c) => ForgeApi::get_pr(c, repo, number).await,
         }
     }
 
     async fn get_prs_batch(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         numbers: &[u64],
     ) -> ForgeResult<HashMap<u64, PullRequest>> {
         match self {
-            Self::GitHub(c) => c.get_prs_batch(owner, repo, numbers).await,
+            Self::GitHub(c) => ForgeApi::get_prs_batch(c, repo, numbers).await,
         }
     }
 
     async fn find_pr_for_branch(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         branch: &str,
     ) -> ForgeResult<Option<PullRequest>> {
         match self {
-            Self::GitHub(c) => c.find_pr_for_branch(owner, repo, branch).await,
+            Self::GitHub(c) => ForgeApi::find_pr_for_branch(c, repo, branch).await,
         }
     }
 
-    async fn create_pr(
-        &self,
-        owner: &str,
-        repo: &str,
-        pr: CreatePullRequest,
-    ) -> ForgeResult<PullRequest> {
+    async fn create_pr(&self, repo: &RepoId, pr: CreatePullRequest) -> ForgeResult<PullRequest> {
         match self {
-            Self::GitHub(c) => c.create_pr(owner, repo, pr).await,
+            Self::GitHub(c) => ForgeApi::create_pr(c, repo, pr).await,
         }
     }
 
     async fn update_pr(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         number: u64,
         update: UpdatePullRequest,
     ) -> ForgeResult<PullRequest> {
         match self {
-            Self::GitHub(c) => c.update_pr(owner, repo, number, update).await,
+            Self::GitHub(c) => ForgeApi::update_pr(c, repo, number, update).await,
         }
     }
 
-    async fn get_check_runs(
-        &self,
-        owner: &str,
-        repo: &str,
-        commit_sha: &str,
-    ) -> ForgeResult<Vec<CheckRun>> {
+    async fn get_check_runs(&self, repo: &RepoId, commit_sha: &str) -> ForgeResult<Vec<CheckRun>> {
         match self {
-            Self::GitHub(c) => c.get_check_runs(owner, repo, commit_sha).await,
+            Self::GitHub(c) => ForgeApi::get_check_runs(c, repo, commit_sha).await,
         }
     }
 
     async fn merge_pr(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         number: u64,
         merge: MergePullRequest,
     ) -> ForgeResult<MergeResult> {
         match self {
-            Self::GitHub(c) => c.merge_pr(owner, repo, number, merge).await,
+            Self::GitHub(c) => ForgeApi::merge_pr(c, repo, number, merge).await,
         }
     }
 
-    async fn delete_ref(&self, owner: &str, repo: &str, ref_name: &str) -> ForgeResult<()> {
+    async fn delete_ref(&self, repo: &RepoId, ref_name: &str) -> ForgeResult<()> {
         match self {
-            Self::GitHub(c) => c.delete_ref(owner, repo, ref_name).await,
+            Self::GitHub(c) => ForgeApi::delete_ref(c, repo, ref_name).await,
         }
     }
 
-    async fn get_default_branch(&self, owner: &str, repo: &str) -> ForgeResult<String> {
+    async fn get_default_branch(&self, repo: &RepoId) -> ForgeResult<String> {
         match self {
-            Self::GitHub(c) => c.get_default_branch(owner, repo).await,
+            Self::GitHub(c) => ForgeApi::get_default_branch(c, repo).await,
         }
     }
 
     async fn list_pr_comments(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         pr_number: u64,
     ) -> ForgeResult<Vec<IssueComment>> {
         match self {
-            Self::GitHub(c) => c.list_pr_comments(owner, repo, pr_number).await,
+            Self::GitHub(c) => ForgeApi::list_pr_comments(c, repo, pr_number).await,
         }
     }
 
     async fn create_pr_comment(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         pr_number: u64,
         comment: CreateComment,
     ) -> ForgeResult<IssueComment> {
         match self {
-            Self::GitHub(c) => c.create_pr_comment(owner, repo, pr_number, comment).await,
+            Self::GitHub(c) => ForgeApi::create_pr_comment(c, repo, pr_number, comment).await,
         }
     }
 
     async fn update_pr_comment(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         comment_id: u64,
         comment: UpdateComment,
     ) -> ForgeResult<IssueComment> {
         match self {
-            Self::GitHub(c) => c.update_pr_comment(owner, repo, comment_id, comment).await,
+            Self::GitHub(c) => ForgeApi::update_pr_comment(c, repo, comment_id, comment).await,
         }
     }
 }

--- a/crates/rung-cli/src/services/absorb.rs
+++ b/crates/rung-cli/src/services/absorb.rs
@@ -35,17 +35,14 @@ impl<'a, G: AbsorbOps> AbsorbService<'a, G> {
             .repo
             .origin_url()
             .context("No origin remote configured")?;
-        let rung_forge::RemoteInfo {
-            owner,
-            repo: repo_name,
-            ..
-        } = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
+        let rung_forge::RemoteInfo { repo: repo_id, .. } =
+            rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
 
         let client = Forge::for_remote(&origin_url, &Auth::auto()).context(
             "GitHub auth required to detect default branch. Use --base <branch> to specify manually.",
         )?;
         client
-            .get_default_branch(&owner, &repo_name)
+            .get_default_branch(&repo_id)
             .await
             .context("Could not fetch default branch. Use --base <branch> to specify manually.")
     }

--- a/crates/rung-cli/src/services/doctor.rs
+++ b/crates/rung-cli/src/services/doctor.rs
@@ -339,11 +339,8 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
             return result;
         };
 
-        let Ok(rung_forge::RemoteInfo {
-            owner,
-            repo: repo_name,
-            ..
-        }) = rung_forge::parse_remote(&origin_url)
+        let Ok(rung_forge::RemoteInfo { repo: repo_id, .. }) =
+            rung_forge::parse_remote(&origin_url)
         else {
             result
                 .issues
@@ -368,7 +365,7 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
             };
 
             // Check if PR is still open
-            match client.get_pr(&owner, &repo_name, pr_number).await {
+            match client.get_pr(&repo_id, pr_number).await {
                 Ok(pr) => {
                     let state_str = match pr.state {
                         PullRequestState::Open => continue,

--- a/crates/rung-cli/src/services/merge.rs
+++ b/crates/rung-cli/src/services/merge.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result, bail};
 use rung_core::stack::Stack;
 use rung_core::{BranchName, StateStore};
 use rung_git::{GitOps, Oid};
-use rung_github::{ForgeApi, MergeMethod, MergePullRequest, UpdatePullRequest};
+use rung_github::{ForgeApi, MergeMethod, MergePullRequest, RepoId, UpdatePullRequest};
 
 /// Information about a descendant branch that was processed.
 #[derive(Debug, Clone)]
@@ -26,20 +26,18 @@ pub struct DescendantResult {
 pub struct MergeService<'a, G: GitOps, H: ForgeApi> {
     repo: &'a G,
     client: &'a H,
-    owner: String,
-    repo_name: String,
+    repo_id: RepoId,
 }
 
 #[allow(clippy::future_not_send)]
 impl<'a, G: GitOps, H: ForgeApi> MergeService<'a, G, H> {
     /// Create a new merge service.
     #[must_use]
-    pub const fn new(repo: &'a G, client: &'a H, owner: String, repo_name: String) -> Self {
+    pub const fn new(repo: &'a G, client: &'a H, repo_id: RepoId) -> Self {
         Self {
             repo,
             client,
-            owner,
-            repo_name,
+            repo_id,
         }
     }
 
@@ -55,7 +53,7 @@ impl<'a, G: GitOps, H: ForgeApi> MergeService<'a, G, H> {
         loop {
             let pr = self
                 .client
-                .get_pr(&self.owner, &self.repo_name, pr_number)
+                .get_pr(&self.repo_id, pr_number)
                 .await
                 .context("Failed to fetch PR status")?;
 
@@ -116,7 +114,7 @@ impl<'a, G: GitOps, H: ForgeApi> MergeService<'a, G, H> {
                 };
                 if let Err(e) = self
                     .client
-                    .update_pr(&self.owner, &self.repo_name, child_pr_num, update)
+                    .update_pr(&self.repo_id, child_pr_num, update)
                     .await
                 {
                     // Best-effort rollback of already-shifted PRs
@@ -148,7 +146,7 @@ impl<'a, G: GitOps, H: ForgeApi> MergeService<'a, G, H> {
             };
             if let Err(e) = self
                 .client
-                .update_pr(&self.owner, &self.repo_name, *child_pr_num, rollback)
+                .update_pr(&self.repo_id, *child_pr_num, rollback)
                 .await
             {
                 failures.push((*child_pr_num, e.to_string()));
@@ -166,7 +164,7 @@ impl<'a, G: GitOps, H: ForgeApi> MergeService<'a, G, H> {
         };
 
         self.client
-            .merge_pr(&self.owner, &self.repo_name, pr_number, merge_request)
+            .merge_pr(&self.repo_id, pr_number, merge_request)
             .await
             .context("Failed to merge PR")?;
 
@@ -324,7 +322,7 @@ impl<'a, G: GitOps, H: ForgeApi> MergeService<'a, G, H> {
                 };
                 match self
                     .client
-                    .update_pr(&self.owner, &self.repo_name, child_pr_num, update)
+                    .update_pr(&self.repo_id, child_pr_num, update)
                     .await
                 {
                     Ok(_) => (true, None),
@@ -348,7 +346,7 @@ impl<'a, G: GitOps, H: ForgeApi> MergeService<'a, G, H> {
     /// Delete the remote branch after merge.
     pub async fn delete_remote_branch(&self, branch: &str) -> Result<()> {
         self.client
-            .delete_ref(&self.owner, &self.repo_name, branch)
+            .delete_ref(&self.repo_id, branch)
             .await
             .context("Failed to delete remote branch")
     }
@@ -743,8 +741,7 @@ mod tests {
         impl rung_github::ForgeApi for MockGitHubClient {
             fn get_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 number: u64,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
             {
@@ -771,8 +768,7 @@ mod tests {
 
             fn get_prs_batch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _numbers: &[u64],
             ) -> impl std::future::Future<
                 Output = rung_github::Result<
@@ -784,8 +780,7 @@ mod tests {
 
             fn find_pr_for_branch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _branch: &str,
             ) -> impl std::future::Future<
                 Output = rung_github::Result<Option<rung_github::PullRequest>>,
@@ -795,8 +790,7 @@ mod tests {
 
             fn create_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _params: rung_github::CreatePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
             {
@@ -805,8 +799,7 @@ mod tests {
 
             fn update_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 number: u64,
                 _params: rung_github::UpdatePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
@@ -837,8 +830,7 @@ mod tests {
 
             fn get_check_runs(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _commit_sha: &str,
             ) -> impl std::future::Future<Output = rung_github::Result<Vec<rung_github::CheckRun>>> + Send
             {
@@ -847,8 +839,7 @@ mod tests {
 
             fn merge_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _number: u64,
                 _params: rung_github::MergePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::MergeResult>> + Send
@@ -872,8 +863,7 @@ mod tests {
 
             fn delete_ref(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _branch: &str,
             ) -> impl std::future::Future<Output = rung_github::Result<()>> + Send {
                 let should_fail = self.delete_should_fail;
@@ -891,16 +881,14 @@ mod tests {
 
             fn get_default_branch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
             ) -> impl std::future::Future<Output = rung_github::Result<String>> + Send {
                 async { Ok("main".to_string()) }
             }
 
             fn list_pr_comments(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _pr_number: u64,
             ) -> impl std::future::Future<
                 Output = rung_github::Result<Vec<rung_github::IssueComment>>,
@@ -910,8 +898,7 @@ mod tests {
 
             fn create_pr_comment(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _pr_number: u64,
                 _comment: rung_github::CreateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send
@@ -926,8 +913,7 @@ mod tests {
 
             fn update_pr_comment(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _comment_id: u64,
                 _comment: rung_github::UpdateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send
@@ -947,11 +933,10 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new();
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             // Service should be created successfully
-            assert_eq!(service.owner, "owner");
-            assert_eq!(service.repo_name, "repo");
+            assert_eq!(service.repo_id.path(), "owner/repo");
         }
 
         #[tokio::test]
@@ -960,7 +945,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new();
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let result = service.validate_mergeable(123).await;
             assert!(result.is_ok());
@@ -975,7 +960,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new().with_unmergeable_pr();
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let result = service.validate_mergeable(123).await;
             assert!(result.is_err());
@@ -990,7 +975,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new().with_unknown_mergeable();
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let result = service.validate_mergeable(123).await;
             assert!(result.is_err());
@@ -1005,7 +990,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new();
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let result = service.merge_pr(123, MergeMethod::Squash).await;
             assert!(result.is_ok());
@@ -1017,7 +1002,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new().with_merge_failure();
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let result = service.merge_pr(123, MergeMethod::Squash).await;
             assert!(result.is_err());
@@ -1029,7 +1014,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new();
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let result = service.delete_remote_branch("feature").await;
             assert!(result.is_ok());
@@ -1041,7 +1026,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new().with_delete_failure();
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let result = service.delete_remote_branch("feature").await;
             assert!(result.is_err());
@@ -1064,7 +1049,7 @@ mod tests {
 
             let state = MockStateStore::new().with_stack(stack);
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let children_count = service
                 .update_stack_after_merge(&state, "feature/parent", "main")
@@ -1097,7 +1082,7 @@ mod tests {
 
             let state = MockStateStore::new().with_stack(stack);
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let children_count = service
                 .update_stack_after_merge(&state, "feature/only", "main")
@@ -1126,7 +1111,7 @@ mod tests {
             child_branch.pr = Some(20);
             stack.add_branch(child_branch);
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let descendants = vec!["feature/child".to_string()];
             let result = service
@@ -1146,7 +1131,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new();
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let shifted_prs = vec![(20, "feature/parent".to_string())];
 
@@ -1164,7 +1149,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new().with_update_pr_failure();
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let shifted_prs = vec![
                 (20, "feature/parent".to_string()),
@@ -1185,7 +1170,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new();
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             // Empty list should return no failures
             let failures = service.rollback_pr_bases(&[]).await;
@@ -1215,7 +1200,7 @@ mod tests {
 
             let state = MockStateStore::new().with_stack(stack.clone());
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut old_commits = HashMap::new();
             old_commits.insert("feature/parent".to_string(), oid);
@@ -1257,7 +1242,7 @@ mod tests {
 
             let state = MockStateStore::new().with_stack(stack.clone());
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut old_commits = HashMap::new();
             old_commits.insert("feature/parent".to_string(), oid);
@@ -1301,7 +1286,7 @@ mod tests {
 
             let state = MockStateStore::new().with_stack(stack.clone());
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut old_commits = HashMap::new();
             old_commits.insert("feature/parent".to_string(), oid);
@@ -1355,7 +1340,7 @@ mod tests {
 
             let state = MockStateStore::new().with_stack(stack.clone());
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut old_commits = HashMap::new();
             old_commits.insert("feature/parent".to_string(), oid);
@@ -1420,7 +1405,7 @@ mod tests {
 
             let state = MockStateStore::new().with_stack(stack.clone());
 
-            let service = MergeService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = MergeService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut old_commits = HashMap::new();
             old_commits.insert("feature/parent".to_string(), oid);

--- a/crates/rung-cli/src/services/submit.rs
+++ b/crates/rung-cli/src/services/submit.rs
@@ -9,7 +9,9 @@ use std::fmt::Write;
 use anyhow::{Context, Result, bail};
 use rung_core::stack::Stack;
 use rung_git::GitOps;
-use rung_github::{CreateComment, CreatePullRequest, ForgeApi, UpdateComment, UpdatePullRequest};
+use rung_github::{
+    CreateComment, CreatePullRequest, ForgeApi, RepoId, UpdateComment, UpdatePullRequest,
+};
 use serde::Serialize;
 
 /// A planned action for a single branch.
@@ -114,8 +116,7 @@ where
 {
     git: &'a G,
     github: &'a H,
-    owner: String,
-    repo: String,
+    repo: RepoId,
 }
 
 #[allow(clippy::future_not_send)] // Git operations are sync; futures don't need to be Send
@@ -125,13 +126,8 @@ where
     H: ForgeApi,
 {
     /// Create a new submit service.
-    pub const fn new(git: &'a G, github: &'a H, owner: String, repo: String) -> Self {
-        Self {
-            git,
-            github,
-            owner,
-            repo,
-        }
+    pub const fn new(git: &'a G, github: &'a H, repo: RepoId) -> Self {
+        Self { git, github, repo }
     }
 
     /// Create a submit plan by analyzing the stack and checking existing PRs.
@@ -163,10 +159,7 @@ where
 
             // Check if PR already exists
             if let Some(pr_number) = branch.pr {
-                let pr_url = format!(
-                    "https://github.com/{}/{}/pull/{pr_number}",
-                    self.owner, self.repo
-                );
+                let pr_url = format!("https://github.com/{}/pull/{pr_number}", self.repo);
                 actions.push(PlannedBranchAction::Update {
                     branch: branch_name.to_string(),
                     pr_number,
@@ -176,7 +169,7 @@ where
             } else {
                 let existing = self
                     .github
-                    .find_pr_for_branch(&self.owner, &self.repo, branch_name)
+                    .find_pr_for_branch(&self.repo, branch_name)
                     .await
                     .context("Failed to check for existing PR")?;
 
@@ -243,7 +236,7 @@ where
                         base: Some(base.clone()),
                     };
                     self.github
-                        .update_pr(&self.owner, &self.repo, *pr_number, update)
+                        .update_pr(&self.repo, *pr_number, update)
                         .await
                         .with_context(|| format!("Failed to update PR #{pr_number}"))?;
 
@@ -277,7 +270,7 @@ where
                     // Check if PR was created between planning and execution
                     let existing = self
                         .github
-                        .find_pr_for_branch(&self.owner, &self.repo, branch)
+                        .find_pr_for_branch(&self.repo, branch)
                         .await
                         .context("Failed to check for existing PR")?;
 
@@ -289,7 +282,7 @@ where
                             base: Some(base.clone()),
                         };
                         self.github
-                            .update_pr(&self.owner, &self.repo, pr.number, update)
+                            .update_pr(&self.repo, pr.number, update)
                             .await
                             .with_context(|| format!("Failed to update PR #{}", pr.number))?;
 
@@ -305,7 +298,7 @@ where
                         };
                         let pr = self
                             .github
-                            .create_pr(&self.owner, &self.repo, create)
+                            .create_pr(&self.repo, create)
                             .await
                             .with_context(|| format!("Failed to create PR for {branch}"))?;
 
@@ -351,7 +344,7 @@ where
             // Find existing rung comment
             let comments = self
                 .github
-                .list_pr_comments(&self.owner, &self.repo, pr_number)
+                .list_pr_comments(&self.repo, pr_number)
                 .await
                 .with_context(|| format!("Failed to list comments on PR #{pr_number}"))?;
 
@@ -364,13 +357,13 @@ where
             if let Some(comment) = existing_comment {
                 let update = UpdateComment { body: comment_body };
                 self.github
-                    .update_pr_comment(&self.owner, &self.repo, comment.id, update)
+                    .update_pr_comment(&self.repo, comment.id, update)
                     .await
                     .with_context(|| format!("Failed to update comment on PR #{pr_number}"))?;
             } else {
                 let create = CreateComment { body: comment_body };
                 self.github
-                    .create_pr_comment(&self.owner, &self.repo, pr_number, create)
+                    .create_pr_comment(&self.repo, pr_number, create)
                     .await
                     .with_context(|| format!("Failed to create comment on PR #{pr_number}"))?;
             }
@@ -1089,8 +1082,7 @@ mod tests {
         impl rung_github::ForgeApi for MockGitHubClient {
             fn get_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 number: u64,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
             {
@@ -1099,8 +1091,7 @@ mod tests {
 
             fn get_prs_batch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _numbers: &[u64],
             ) -> impl std::future::Future<
                 Output = rung_github::Result<
@@ -1112,8 +1103,7 @@ mod tests {
 
             fn find_pr_for_branch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _branch: &str,
             ) -> impl std::future::Future<
                 Output = rung_github::Result<Option<rung_github::PullRequest>>,
@@ -1124,8 +1114,7 @@ mod tests {
 
             fn create_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 params: rung_github::CreatePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
             {
@@ -1147,8 +1136,7 @@ mod tests {
 
             fn update_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 number: u64,
                 _params: rung_github::UpdatePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
@@ -1171,8 +1159,7 @@ mod tests {
 
             fn get_check_runs(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _commit_sha: &str,
             ) -> impl std::future::Future<Output = rung_github::Result<Vec<rung_github::CheckRun>>> + Send
             {
@@ -1181,8 +1168,7 @@ mod tests {
 
             fn merge_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _number: u64,
                 _params: rung_github::MergePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::MergeResult>> + Send
@@ -1198,8 +1184,7 @@ mod tests {
 
             fn delete_ref(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _ref_name: &str,
             ) -> impl std::future::Future<Output = rung_github::Result<()>> + Send {
                 async { Ok(()) }
@@ -1207,16 +1192,14 @@ mod tests {
 
             fn get_default_branch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
             ) -> impl std::future::Future<Output = rung_github::Result<String>> + Send {
                 async { Ok("main".to_string()) }
             }
 
             fn list_pr_comments(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _pr_number: u64,
             ) -> impl std::future::Future<
                 Output = rung_github::Result<Vec<rung_github::IssueComment>>,
@@ -1226,8 +1209,7 @@ mod tests {
 
             fn create_pr_comment(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _pr_number: u64,
                 _comment: rung_github::CreateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send
@@ -1242,8 +1224,7 @@ mod tests {
 
             fn update_pr_comment(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _comment_id: u64,
                 _comment: rung_github::UpdateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send
@@ -1263,8 +1244,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("main", oid);
             let github = MockGitHubClient::new();
 
-            let service =
-                SubmitService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = SubmitService::new(&git, &github, RepoId::new("owner/repo"));
             let stack = Stack::default();
             let config = SubmitConfig {
                 draft: false,
@@ -1285,8 +1265,7 @@ mod tests {
                 .with_branch("feature/a", oid);
             let github = MockGitHubClient::new();
 
-            let service =
-                SubmitService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = SubmitService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut stack = Stack::default();
             stack.add_branch(StackBranch::try_new("feature/a", None::<&str>).unwrap());
@@ -1311,8 +1290,7 @@ mod tests {
                 .with_branch("feature/a", oid);
             let github = MockGitHubClient::new();
 
-            let service =
-                SubmitService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = SubmitService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut stack = Stack::default();
             let mut branch = StackBranch::try_new("feature/a", None::<&str>).unwrap();
@@ -1339,8 +1317,7 @@ mod tests {
                 .with_branch("feature/a", oid);
             let github = MockGitHubClient::new();
 
-            let service =
-                SubmitService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = SubmitService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut stack = Stack::default();
             stack.add_branch(StackBranch::try_new("feature/a", None::<&str>).unwrap());
@@ -1368,8 +1345,7 @@ mod tests {
             let git = MockGitOps::new().with_branch("feature/test", oid);
             let github = MockGitHubClient::new();
 
-            let service =
-                SubmitService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = SubmitService::new(&git, &github, RepoId::new("owner/repo"));
 
             // MockGitOps returns "Test commit message" for branch_commit_message
             let (title, body) = service.get_pr_title_and_body("feature/test");
@@ -1382,8 +1358,7 @@ mod tests {
             let git = MockGitOps::new();
             let github = MockGitHubClient::new();
 
-            let _service =
-                SubmitService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let _service = SubmitService::new(&git, &github, RepoId::new("owner/repo"));
             // Service is created successfully
         }
 
@@ -1396,8 +1371,7 @@ mod tests {
                 .with_push_result("feature/a", true);
             let github = MockGitHubClient::new();
 
-            let service =
-                SubmitService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = SubmitService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut stack = Stack::default();
             stack.add_branch(StackBranch::try_new("feature/a", None::<&str>).unwrap());
@@ -1432,8 +1406,7 @@ mod tests {
                 .with_push_result("feature/a", true);
             let github = MockGitHubClient::new();
 
-            let service =
-                SubmitService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = SubmitService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut stack = Stack::default();
             let mut branch = StackBranch::try_new("feature/a", None::<&str>).unwrap();
@@ -1468,8 +1441,7 @@ mod tests {
                 .with_push_result("feature/b", true);
             let github = MockGitHubClient::new();
 
-            let service =
-                SubmitService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = SubmitService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut stack = Stack::default();
             let mut branch_a = StackBranch::try_new("feature/a", None::<&str>).unwrap();
@@ -1514,8 +1486,7 @@ mod tests {
                 .with_push_result("feature/a", true);
             let github = MockGitHubClient::new();
 
-            let service =
-                SubmitService::new(&git, &github, "owner".to_string(), "repo".to_string());
+            let service = SubmitService::new(&git, &github, RepoId::new("owner/repo"));
 
             let mut stack = Stack::default();
             stack.add_branch(StackBranch::try_new("feature/a", None::<&str>).unwrap());

--- a/crates/rung-cli/src/services/sync.rs
+++ b/crates/rung-cli/src/services/sync.rs
@@ -12,7 +12,7 @@ use rung_core::sync::{
     self, ExternalMergeInfo, ReconcileResult, ReparentedBranch, StaleBranches, SyncPlan, SyncResult,
 };
 use rung_git::GitOps;
-use rung_github::{ForgeApi, PullRequestState, UpdatePullRequest};
+use rung_github::{ForgeApi, PullRequestState, RepoId, UpdatePullRequest};
 
 /// Threshold for switching from individual REST calls to batched GraphQL query.
 const BATCH_THRESHOLD: usize = 5;
@@ -21,20 +21,18 @@ const BATCH_THRESHOLD: usize = 5;
 pub struct SyncService<'a, G: GitOps, H: ForgeApi> {
     repo: &'a G,
     client: &'a H,
-    owner: String,
-    repo_name: String,
+    repo_id: RepoId,
 }
 
 #[allow(clippy::future_not_send)]
 impl<'a, G: GitOps, H: ForgeApi> SyncService<'a, G, H> {
     /// Create a new sync service.
     #[must_use]
-    pub const fn new(repo: &'a G, client: &'a H, owner: String, repo_name: String) -> Self {
+    pub const fn new(repo: &'a G, client: &'a H, repo_id: RepoId) -> Self {
         Self {
             repo,
             client,
-            owner,
-            repo_name,
+            repo_id,
         }
     }
 
@@ -79,11 +77,7 @@ impl<'a, G: GitOps, H: ForgeApi> SyncService<'a, G, H> {
         if branches_with_prs.len() > BATCH_THRESHOLD {
             let pr_numbers: Vec<u64> = branches_with_prs.iter().map(|(_, _, pr)| *pr).collect();
 
-            match self
-                .client
-                .get_prs_batch(&self.owner, &self.repo_name, &pr_numbers)
-                .await
-            {
+            match self.client.get_prs_batch(&self.repo_id, &pr_numbers).await {
                 Ok(pr_map) => {
                     for (branch_name, stack_parent, pr_number) in &branches_with_prs {
                         if let Some(pr) = pr_map.get(pr_number) {
@@ -145,11 +139,7 @@ impl<'a, G: GitOps, H: ForgeApi> SyncService<'a, G, H> {
         ghost_parents: &mut Vec<ReparentedBranch>,
     ) {
         for (branch_name, stack_parent, pr_number) in branches_with_prs {
-            match self
-                .client
-                .get_pr(&self.owner, &self.repo_name, *pr_number)
-                .await
-            {
+            match self.client.get_pr(&self.repo_id, *pr_number).await {
                 Ok(pr) => {
                     Self::process_pr_result(
                         &pr,
@@ -261,11 +251,7 @@ impl<'a, G: GitOps, H: ForgeApi> SyncService<'a, G, H> {
         let pr_numbers: Vec<u64> = updates_needed.iter().map(|(pr, _, _)| *pr).collect();
 
         let current_states: HashMap<u64, String> = if pr_numbers.len() > BATCH_THRESHOLD {
-            match self
-                .client
-                .get_prs_batch(&self.owner, &self.repo_name, &pr_numbers)
-                .await
-            {
+            match self.client.get_prs_batch(&self.repo_id, &pr_numbers).await {
                 Ok(prs) => prs
                     .into_iter()
                     .map(|(num, pr)| (num, pr.base_branch))
@@ -293,7 +279,7 @@ impl<'a, G: GitOps, H: ForgeApi> SyncService<'a, G, H> {
 
             if let Err(e) = self
                 .client
-                .update_pr(&self.owner, &self.repo_name, pr_number, update)
+                .update_pr(&self.repo_id, pr_number, update)
                 .await
             {
                 eprintln!("Warning: Failed to update PR #{pr_number} base to '{new_base}': {e}");
@@ -307,11 +293,7 @@ impl<'a, G: GitOps, H: ForgeApi> SyncService<'a, G, H> {
     async fn fetch_current_bases(&self, pr_numbers: &[u64]) -> HashMap<u64, String> {
         let mut result = HashMap::new();
         for &pr_number in pr_numbers {
-            if let Ok(pr) = self
-                .client
-                .get_pr(&self.owner, &self.repo_name, pr_number)
-                .await
-            {
+            if let Ok(pr) = self.client.get_pr(&self.repo_id, pr_number).await {
                 result.insert(pr_number, pr.base_branch);
             }
         }
@@ -655,8 +637,7 @@ mod tests {
         impl rung_github::ForgeApi for MockGitHubClient {
             fn get_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 number: u64,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
             {
@@ -665,8 +646,7 @@ mod tests {
 
             fn get_prs_batch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _numbers: &[u64],
             ) -> impl std::future::Future<
                 Output = rung_github::Result<
@@ -678,8 +658,7 @@ mod tests {
 
             fn find_pr_for_branch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _branch: &str,
             ) -> impl std::future::Future<
                 Output = rung_github::Result<Option<rung_github::PullRequest>>,
@@ -689,8 +668,7 @@ mod tests {
 
             fn create_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _params: rung_github::CreatePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
             {
@@ -699,8 +677,7 @@ mod tests {
 
             fn update_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 number: u64,
                 _params: rung_github::UpdatePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
@@ -710,8 +687,7 @@ mod tests {
 
             fn get_check_runs(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _commit_sha: &str,
             ) -> impl std::future::Future<Output = rung_github::Result<Vec<rung_github::CheckRun>>> + Send
             {
@@ -720,8 +696,7 @@ mod tests {
 
             fn merge_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _number: u64,
                 _params: rung_github::MergePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::MergeResult>> + Send
@@ -737,8 +712,7 @@ mod tests {
 
             fn delete_ref(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _ref_name: &str,
             ) -> impl std::future::Future<Output = rung_github::Result<()>> + Send {
                 async { Ok(()) }
@@ -746,16 +720,14 @@ mod tests {
 
             fn get_default_branch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
             ) -> impl std::future::Future<Output = rung_github::Result<String>> + Send {
                 async { Ok("main".to_string()) }
             }
 
             fn list_pr_comments(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _pr_number: u64,
             ) -> impl std::future::Future<
                 Output = rung_github::Result<Vec<rung_github::IssueComment>>,
@@ -765,8 +737,7 @@ mod tests {
 
             fn create_pr_comment(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _pr_number: u64,
                 _comment: rung_github::CreateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send
@@ -781,8 +752,7 @@ mod tests {
 
             fn update_pr_comment(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _comment_id: u64,
                 _comment: rung_github::UpdateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send
@@ -802,7 +772,7 @@ mod tests {
             let state = MockStateStore::new();
             let client = MockGitHubClient;
 
-            let service = SyncService::new(&git, &client, "owner".to_string(), "repo".to_string());
+            let service = SyncService::new(&git, &client, RepoId::new("owner/repo"));
             let result = service.push_stack_branches(&state).unwrap();
 
             assert!(result.is_empty());
@@ -822,7 +792,7 @@ mod tests {
             let state = MockStateStore::new().with_stack(stack);
             let client = MockGitHubClient;
 
-            let service = SyncService::new(&git, &client, "owner".to_string(), "repo".to_string());
+            let service = SyncService::new(&git, &client, RepoId::new("owner/repo"));
             let result = service.push_stack_branches(&state).unwrap();
 
             assert_eq!(result.len(), 2);
@@ -844,7 +814,7 @@ mod tests {
             let state = MockStateStore::new().with_stack(stack);
             let client = MockGitHubClient;
 
-            let service = SyncService::new(&git, &client, "owner".to_string(), "repo".to_string());
+            let service = SyncService::new(&git, &client, RepoId::new("owner/repo"));
             let result = service.push_stack_branches(&state).unwrap();
 
             assert_eq!(result.len(), 2);
@@ -865,7 +835,7 @@ mod tests {
             let state = MockStateStore::new().with_stack(stack);
             let client = MockGitHubClient;
 
-            let service = SyncService::new(&git, &client, "owner".to_string(), "repo".to_string());
+            let service = SyncService::new(&git, &client, RepoId::new("owner/repo"));
             let result = service.push_stack_branches(&state).unwrap();
 
             // Only feature/a should be pushed (feature/b doesn't exist in git)
@@ -878,7 +848,7 @@ mod tests {
             let git = MockGitOps::new();
             let client = MockGitHubClient;
 
-            let service = SyncService::new(&git, &client, "owner".to_string(), "repo".to_string());
+            let service = SyncService::new(&git, &client, RepoId::new("owner/repo"));
             let result = service.fetch_base("main");
 
             assert!(result.is_ok());
@@ -889,12 +859,7 @@ mod tests {
             let git = MockGitOps::new();
             let client = MockGitHubClient;
 
-            let service = SyncService::new(
-                &git,
-                &client,
-                "test-owner".to_string(),
-                "test-repo".to_string(),
-            );
+            let service = SyncService::new(&git, &client, RepoId::new("test-owner/test-repo"));
 
             // Service is created successfully - we can't access private fields
             // but we can verify it doesn't panic
@@ -929,8 +894,7 @@ mod tests {
         impl rung_github::ForgeApi for ConfigurableMockGitHubClient {
             fn get_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 number: u64,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
             {
@@ -962,8 +926,7 @@ mod tests {
 
             fn get_prs_batch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 numbers: &[u64],
             ) -> impl std::future::Future<
                 Output = rung_github::Result<
@@ -1003,8 +966,7 @@ mod tests {
 
             fn find_pr_for_branch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _branch: &str,
             ) -> impl std::future::Future<
                 Output = rung_github::Result<Option<rung_github::PullRequest>>,
@@ -1014,8 +976,7 @@ mod tests {
 
             fn create_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _params: rung_github::CreatePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
             {
@@ -1024,8 +985,7 @@ mod tests {
 
             fn update_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 number: u64,
                 _params: rung_github::UpdatePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
@@ -1048,8 +1008,7 @@ mod tests {
 
             fn get_check_runs(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _commit_sha: &str,
             ) -> impl std::future::Future<Output = rung_github::Result<Vec<rung_github::CheckRun>>> + Send
             {
@@ -1058,8 +1017,7 @@ mod tests {
 
             fn merge_pr(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _number: u64,
                 _params: rung_github::MergePullRequest,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::MergeResult>> + Send
@@ -1075,8 +1033,7 @@ mod tests {
 
             fn delete_ref(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _ref_name: &str,
             ) -> impl std::future::Future<Output = rung_github::Result<()>> + Send {
                 async { Ok(()) }
@@ -1084,16 +1041,14 @@ mod tests {
 
             fn get_default_branch(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
             ) -> impl std::future::Future<Output = rung_github::Result<String>> + Send {
                 async { Ok("main".to_string()) }
             }
 
             fn list_pr_comments(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _pr_number: u64,
             ) -> impl std::future::Future<
                 Output = rung_github::Result<Vec<rung_github::IssueComment>>,
@@ -1103,8 +1058,7 @@ mod tests {
 
             fn create_pr_comment(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _pr_number: u64,
                 _comment: rung_github::CreateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send
@@ -1119,8 +1073,7 @@ mod tests {
 
             fn update_pr_comment(
                 &self,
-                _owner: &str,
-                _repo: &str,
+                _repo: &rung_github::RepoId,
                 _comment_id: u64,
                 _comment: rung_github::UpdateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send
@@ -1140,7 +1093,7 @@ mod tests {
             let client = ConfigurableMockGitHubClient::new();
             let state = MockStateStore::new();
 
-            let service = SyncService::new(&git, &client, "owner".to_string(), "repo".to_string());
+            let service = SyncService::new(&git, &client, RepoId::new("owner/repo"));
 
             let result = service.detect_and_reconcile_merged(&state, "main").await;
             assert!(result.is_ok());
@@ -1163,7 +1116,7 @@ mod tests {
 
             let state = MockStateStore::new().with_stack(stack);
 
-            let service = SyncService::new(&git, &client, "owner".to_string(), "repo".to_string());
+            let service = SyncService::new(&git, &client, RepoId::new("owner/repo"));
 
             let result = service.detect_and_reconcile_merged(&state, "main").await;
             assert!(result.is_ok());
@@ -1188,7 +1141,7 @@ mod tests {
 
             let state = MockStateStore::new().with_stack(stack);
 
-            let service = SyncService::new(&git, &client, "owner".to_string(), "repo".to_string());
+            let service = SyncService::new(&git, &client, RepoId::new("owner/repo"));
 
             let result = service.detect_and_reconcile_merged(&state, "main").await;
             assert!(result.is_ok());
@@ -1212,7 +1165,7 @@ mod tests {
 
             let state = MockStateStore::new().with_stack(stack);
 
-            let service = SyncService::new(&git, &client, "owner".to_string(), "repo".to_string());
+            let service = SyncService::new(&git, &client, RepoId::new("owner/repo"));
 
             let result = service.detect_and_reconcile_merged(&state, "main").await;
             assert!(result.is_ok());
@@ -1230,7 +1183,7 @@ mod tests {
             let git = MockGitOps::new();
             let client = ConfigurableMockGitHubClient::new();
 
-            let service = SyncService::new(&git, &client, "owner".to_string(), "repo".to_string());
+            let service = SyncService::new(&git, &client, RepoId::new("owner/repo"));
 
             let empty_result = rung_core::sync::ReconcileResult::default();
             let result = service.update_pr_bases(&empty_result).await;
@@ -1242,7 +1195,7 @@ mod tests {
             let git = MockGitOps::new();
             let client = ConfigurableMockGitHubClient::new().with_pr_base(10, "old-parent");
 
-            let service = SyncService::new(&git, &client, "owner".to_string(), "repo".to_string());
+            let service = SyncService::new(&git, &client, RepoId::new("owner/repo"));
 
             let reconcile_result = rung_core::sync::ReconcileResult {
                 merged: vec![],

--- a/crates/rung-forge/src/lib.rs
+++ b/crates/rung-forge/src/lib.rs
@@ -10,11 +10,13 @@
 
 mod error;
 mod remote;
+mod repo_id;
 mod traits;
 mod types;
 
 pub use error::{ForgeError, Result};
 pub use remote::{ForgeKind, RemoteInfo, parse_remote};
+pub use repo_id::RepoId;
 pub use traits::ForgeApi;
 pub use types::{
     CheckRun, CheckStatus, CreateComment, CreatePullRequest, IssueComment, MergeMethod,

--- a/crates/rung-forge/src/remote.rs
+++ b/crates/rung-forge/src/remote.rs
@@ -5,7 +5,7 @@
 //! logic in the contract crate means `rung-git` stays forge-agnostic and new
 //! backends extend detection in one place.
 
-use crate::{ForgeError, Result};
+use crate::{ForgeError, RepoId, Result};
 
 /// A supported code-hosting forge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -36,10 +36,8 @@ impl ForgeKind {
 pub struct RemoteInfo {
     /// The forge hosting the repository.
     pub kind: ForgeKind,
-    /// Repository owner (user or organization).
-    pub owner: String,
-    /// Repository name.
-    pub repo: String,
+    /// Forge-neutral identifier for the repository/project.
+    pub repo: RepoId,
 }
 
 /// Parse a git remote URL into its forge, owner, and repository.
@@ -72,6 +70,8 @@ fn parse_github(url: &str) -> Result<RemoteInfo> {
         let path = path.strip_suffix(".git").unwrap_or(path);
         // Require exactly `owner/repo` — reject extra path segments so a
         // malformed remote fails here rather than later as a bad API repo name.
+        // The guard proves `path` is exactly two non-empty segments, so it is
+        // already the canonical `owner/repo` slug; use it as-is.
         let mut parts = path.split('/');
         if let (Some(owner), Some(repo), None) = (parts.next(), parts.next(), parts.next())
             && !owner.is_empty()
@@ -79,8 +79,7 @@ fn parse_github(url: &str) -> Result<RemoteInfo> {
         {
             return Ok(RemoteInfo {
                 kind: ForgeKind::GitHub,
-                owner: owner.to_string(),
-                repo: repo.to_string(),
+                repo: RepoId::new(path),
             });
         }
     }
@@ -120,23 +119,20 @@ mod tests {
     fn test_parse_https_with_git_suffix() {
         let info = parse_remote("https://github.com/octocat/hello-world.git").unwrap();
         assert_eq!(info.kind, ForgeKind::GitHub);
-        assert_eq!(info.owner, "octocat");
-        assert_eq!(info.repo, "hello-world");
+        assert_eq!(info.repo.path(), "octocat/hello-world");
     }
 
     #[test]
     fn test_parse_https_without_git_suffix() {
         let info = parse_remote("https://github.com/octocat/hello-world").unwrap();
-        assert_eq!(info.owner, "octocat");
-        assert_eq!(info.repo, "hello-world");
+        assert_eq!(info.repo.path(), "octocat/hello-world");
     }
 
     #[test]
     fn test_parse_ssh() {
         let info = parse_remote("git@github.com:octocat/hello-world.git").unwrap();
         assert_eq!(info.kind, ForgeKind::GitHub);
-        assert_eq!(info.owner, "octocat");
-        assert_eq!(info.repo, "hello-world");
+        assert_eq!(info.repo.path(), "octocat/hello-world");
     }
 
     #[test]
@@ -161,12 +157,11 @@ mod tests {
     #[test]
     fn test_parse_trailing_slash_is_trimmed() {
         let info = parse_remote("https://github.com/octocat/hello-world/").unwrap();
-        assert_eq!(info.owner, "octocat");
-        assert_eq!(info.repo, "hello-world");
+        assert_eq!(info.repo.path(), "octocat/hello-world");
 
         // Trailing slash after the `.git` suffix is also tolerated.
         let info = parse_remote("https://github.com/octocat/hello-world.git/").unwrap();
-        assert_eq!(info.repo, "hello-world");
+        assert_eq!(info.repo.path(), "octocat/hello-world");
     }
 
     #[test]

--- a/crates/rung-forge/src/repo_id.rs
+++ b/crates/rung-forge/src/repo_id.rs
@@ -1,0 +1,71 @@
+//! Forge-neutral repository identifier.
+
+use std::fmt;
+
+/// A forge-neutral identifier for a repository (GitHub) or project (GitLab).
+///
+/// Different forges name repositories differently:
+/// - GitHub uses a flat `owner/repo` pair.
+/// - GitLab uses a nested namespace path (`group/subgroup/project`) or a
+///   numeric project ID — neither of which an `owner`/`repo` pair can represent.
+///
+/// `RepoId` stores the canonical, forge-native project *path* as a single
+/// string so both models map onto one type. Each backend interprets it:
+/// the GitHub client splits it into `owner` and `repo` on its single `/`,
+/// while a GitLab client URL-encodes the whole path for its API.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RepoId {
+    path: String,
+}
+
+impl RepoId {
+    /// Create a `RepoId` from a forge-native project path.
+    ///
+    /// The path is the full slug as the forge names it, e.g. `owner/repo`
+    /// for GitHub or `group/subgroup/project` for GitLab.
+    pub fn new(path: impl Into<String>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// The forge-native project path (e.g. `owner/repo` or `group/sub/project`).
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+impl fmt::Display for RepoId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_roundtrips() {
+        let id = RepoId::new("octocat/hello-world");
+        assert_eq!(id.path(), "octocat/hello-world");
+    }
+
+    #[test]
+    fn test_accepts_nested_namespace() {
+        let id = RepoId::new("group/subgroup/project");
+        assert_eq!(id.path(), "group/subgroup/project");
+    }
+
+    #[test]
+    fn test_display_is_path() {
+        assert_eq!(RepoId::new("a/b").to_string(), "a/b");
+    }
+
+    #[test]
+    fn test_equality_and_clone() {
+        let a = RepoId::new("o/r");
+        let b = a.clone();
+        assert_eq!(a, b);
+        assert_ne!(a, RepoId::new("o/other"));
+    }
+}

--- a/crates/rung-forge/src/traits.rs
+++ b/crates/rung-forge/src/traits.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use crate::{
     CheckRun, CreateComment, CreatePullRequest, IssueComment, MergePullRequest, MergeResult,
-    PullRequest, Result, UpdateComment, UpdatePullRequest,
+    PullRequest, RepoId, Result, UpdateComment, UpdatePullRequest,
 };
 
 /// Trait for forge (code-hosting) API operations.
@@ -19,16 +19,15 @@ use crate::{
 /// - Mock implementations for testing
 /// - Alternative backends (e.g. GitLab, Bitbucket) and modes (offline, caching)
 ///
-/// All methods take `owner` and `repo` as parameters to support
-/// operations across different repositories.
+/// All methods take a forge-neutral [`RepoId`] identifying the target
+/// repository/project, so call sites stay backend-agnostic.
 pub trait ForgeApi: Send + Sync {
     // === PR Operations ===
 
     /// Get a pull request by number.
     fn get_pr(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         number: u64,
     ) -> impl std::future::Future<Output = Result<PullRequest>> + Send;
 
@@ -37,8 +36,7 @@ pub trait ForgeApi: Send + Sync {
     /// Returns a map of PR number to PR data. Missing PRs are omitted.
     fn get_prs_batch(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         numbers: &[u64],
     ) -> impl std::future::Future<Output = Result<HashMap<u64, PullRequest>>> + Send;
 
@@ -47,24 +45,21 @@ pub trait ForgeApi: Send + Sync {
     /// Returns `None` if no open PR exists for the branch.
     fn find_pr_for_branch(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         branch: &str,
     ) -> impl std::future::Future<Output = Result<Option<PullRequest>>> + Send;
 
     /// Create a pull request.
     fn create_pr(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         pr: CreatePullRequest,
     ) -> impl std::future::Future<Output = Result<PullRequest>> + Send;
 
     /// Update a pull request.
     fn update_pr(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         number: u64,
         update: UpdatePullRequest,
     ) -> impl std::future::Future<Output = Result<PullRequest>> + Send;
@@ -74,8 +69,7 @@ pub trait ForgeApi: Send + Sync {
     /// Get check runs for a commit.
     fn get_check_runs(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         commit_sha: &str,
     ) -> impl std::future::Future<Output = Result<Vec<CheckRun>>> + Send;
 
@@ -84,8 +78,7 @@ pub trait ForgeApi: Send + Sync {
     /// Merge a pull request.
     fn merge_pr(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         number: u64,
         merge: MergePullRequest,
     ) -> impl std::future::Future<Output = Result<MergeResult>> + Send;
@@ -95,8 +88,7 @@ pub trait ForgeApi: Send + Sync {
     /// Delete a git reference (branch).
     fn delete_ref(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         ref_name: &str,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
 
@@ -105,8 +97,7 @@ pub trait ForgeApi: Send + Sync {
     /// Get the repository's default branch name.
     fn get_default_branch(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
     ) -> impl std::future::Future<Output = Result<String>> + Send;
 
     // === Comment Operations ===
@@ -114,16 +105,14 @@ pub trait ForgeApi: Send + Sync {
     /// List comments on a pull request.
     fn list_pr_comments(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         pr_number: u64,
     ) -> impl std::future::Future<Output = Result<Vec<IssueComment>>> + Send;
 
     /// Create a comment on a pull request.
     fn create_pr_comment(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         pr_number: u64,
         comment: CreateComment,
     ) -> impl std::future::Future<Output = Result<IssueComment>> + Send;
@@ -131,8 +120,7 @@ pub trait ForgeApi: Send + Sync {
     /// Update a comment on a pull request.
     fn update_pr_comment(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         comment_id: u64,
         comment: UpdateComment,
     ) -> impl std::future::Future<Output = Result<IssueComment>> + Send;

--- a/crates/rung-github/src/client.rs
+++ b/crates/rung-github/src/client.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 
 use rung_forge::{
     CheckRun, CreateComment, CreatePullRequest, ForgeApi, ForgeError as Error, IssueComment,
-    MergePullRequest, MergeResult, PullRequest, PullRequestState, Result, UpdateComment,
+    MergePullRequest, MergeResult, PullRequest, PullRequestState, RepoId, Result, UpdateComment,
     UpdatePullRequest,
 };
 
@@ -713,103 +713,103 @@ fn build_graphql_pr_query(numbers: &[u64]) -> String {
 
 // === Trait Implementation ===
 
+/// Split a forge-neutral [`RepoId`] into GitHub's `(owner, repo)` pair.
+///
+/// GitHub repositories are always exactly `owner/repo`; [`parse_remote`]
+/// guarantees that shape, so a single `/` split is sufficient.
+///
+/// [`parse_remote`]: rung_forge::parse_remote
+fn github_parts(repo: &RepoId) -> Result<(&str, &str)> {
+    repo.path()
+        .split_once('/')
+        .filter(|(owner, name)| !owner.is_empty() && !name.is_empty() && !name.contains('/'))
+        .ok_or_else(|| Error::InvalidRemoteUrl(repo.path().to_string()))
+}
+
 impl ForgeApi for GitHubClient {
-    async fn get_pr(&self, owner: &str, repo: &str, number: u64) -> Result<PullRequest> {
-        self.get_pr(owner, repo, number).await
+    async fn get_pr(&self, repo: &RepoId, number: u64) -> Result<PullRequest> {
+        let (owner, name) = github_parts(repo)?;
+        self.get_pr(owner, name, number).await
     }
 
     async fn get_prs_batch(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         numbers: &[u64],
     ) -> Result<std::collections::HashMap<u64, PullRequest>> {
-        self.get_prs_batch(owner, repo, numbers).await
+        let (owner, name) = github_parts(repo)?;
+        self.get_prs_batch(owner, name, numbers).await
     }
 
-    async fn find_pr_for_branch(
-        &self,
-        owner: &str,
-        repo: &str,
-        branch: &str,
-    ) -> Result<Option<PullRequest>> {
-        self.find_pr_for_branch(owner, repo, branch).await
+    async fn find_pr_for_branch(&self, repo: &RepoId, branch: &str) -> Result<Option<PullRequest>> {
+        let (owner, name) = github_parts(repo)?;
+        self.find_pr_for_branch(owner, name, branch).await
     }
 
-    async fn create_pr(
-        &self,
-        owner: &str,
-        repo: &str,
-        pr: CreatePullRequest,
-    ) -> Result<PullRequest> {
-        self.create_pr(owner, repo, pr).await
+    async fn create_pr(&self, repo: &RepoId, pr: CreatePullRequest) -> Result<PullRequest> {
+        let (owner, name) = github_parts(repo)?;
+        self.create_pr(owner, name, pr).await
     }
 
     async fn update_pr(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         number: u64,
         update: UpdatePullRequest,
     ) -> Result<PullRequest> {
-        self.update_pr(owner, repo, number, update).await
+        let (owner, name) = github_parts(repo)?;
+        self.update_pr(owner, name, number, update).await
     }
 
-    async fn get_check_runs(
-        &self,
-        owner: &str,
-        repo: &str,
-        commit_sha: &str,
-    ) -> Result<Vec<CheckRun>> {
-        self.get_check_runs(owner, repo, commit_sha).await
+    async fn get_check_runs(&self, repo: &RepoId, commit_sha: &str) -> Result<Vec<CheckRun>> {
+        let (owner, name) = github_parts(repo)?;
+        self.get_check_runs(owner, name, commit_sha).await
     }
 
     async fn merge_pr(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         number: u64,
         merge: MergePullRequest,
     ) -> Result<MergeResult> {
-        self.merge_pr(owner, repo, number, merge).await
+        let (owner, name) = github_parts(repo)?;
+        self.merge_pr(owner, name, number, merge).await
     }
 
-    async fn delete_ref(&self, owner: &str, repo: &str, ref_name: &str) -> Result<()> {
-        self.delete_ref(owner, repo, ref_name).await
+    async fn delete_ref(&self, repo: &RepoId, ref_name: &str) -> Result<()> {
+        let (owner, name) = github_parts(repo)?;
+        self.delete_ref(owner, name, ref_name).await
     }
 
-    async fn get_default_branch(&self, owner: &str, repo: &str) -> Result<String> {
-        self.get_default_branch(owner, repo).await
+    async fn get_default_branch(&self, repo: &RepoId) -> Result<String> {
+        let (owner, name) = github_parts(repo)?;
+        self.get_default_branch(owner, name).await
     }
 
-    async fn list_pr_comments(
-        &self,
-        owner: &str,
-        repo: &str,
-        pr_number: u64,
-    ) -> Result<Vec<IssueComment>> {
-        self.list_pr_comments(owner, repo, pr_number).await
+    async fn list_pr_comments(&self, repo: &RepoId, pr_number: u64) -> Result<Vec<IssueComment>> {
+        let (owner, name) = github_parts(repo)?;
+        self.list_pr_comments(owner, name, pr_number).await
     }
 
     async fn create_pr_comment(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         pr_number: u64,
         comment: CreateComment,
     ) -> Result<IssueComment> {
-        self.create_pr_comment(owner, repo, pr_number, comment)
+        let (owner, name) = github_parts(repo)?;
+        self.create_pr_comment(owner, name, pr_number, comment)
             .await
     }
 
     async fn update_pr_comment(
         &self,
-        owner: &str,
-        repo: &str,
+        repo: &RepoId,
         comment_id: u64,
         comment: UpdateComment,
     ) -> Result<IssueComment> {
-        self.update_pr_comment(owner, repo, comment_id, comment)
+        let (owner, name) = github_parts(repo)?;
+        self.update_pr_comment(owner, name, comment_id, comment)
             .await
     }
 }
@@ -822,6 +822,30 @@ mod tests {
     use secrecy::SecretString;
     use wiremock::matchers::{header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn test_github_parts_splits_owner_repo() {
+        let repo = RepoId::new("octocat/hello-world");
+        let (owner, name) = github_parts(&repo).unwrap();
+        assert_eq!(owner, "octocat");
+        assert_eq!(name, "hello-world");
+    }
+
+    #[test]
+    fn test_github_parts_rejects_nested_path() {
+        // GitHub repos are exactly `owner/repo`; a nested GitLab-style path is invalid here.
+        assert!(matches!(
+            github_parts(&RepoId::new("group/subgroup/project")),
+            Err(Error::InvalidRemoteUrl(_))
+        ));
+    }
+
+    #[test]
+    fn test_github_parts_rejects_missing_separator() {
+        assert!(github_parts(&RepoId::new("justone")).is_err());
+        assert!(github_parts(&RepoId::new("owner/")).is_err());
+        assert!(github_parts(&RepoId::new("/repo")).is_err());
+    }
 
     /// Create a test client pointing to the mock server.
     fn test_client(base_url: &str) -> GitHubClient {
@@ -868,6 +892,30 @@ mod tests {
         assert_eq!(pr.title, "PR #123");
         assert_eq!(pr.state, PullRequestState::Open);
         assert_eq!(pr.head_branch, "feature-branch");
+        assert_eq!(pr.base_branch, "main");
+    }
+
+    #[tokio::test]
+    async fn test_forge_api_get_pr_splits_repo_id_to_url() {
+        // Exercises the `ForgeApi` adapter end-to-end: a `RepoId` must be split
+        // into `owner`/`repo` and reach the same wire URL as the inherent call.
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo/pulls/123"))
+            .and(header("authorization", "Bearer test-token"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(pr_response_json(123, "open", false)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = test_client(&mock_server.uri());
+        let pr = ForgeApi::get_pr(&client, &RepoId::new("owner/repo"), 123)
+            .await
+            .unwrap();
+
+        assert_eq!(pr.number, 123);
         assert_eq!(pr.base_branch, "main");
     }
 

--- a/crates/rung-github/src/lib.rs
+++ b/crates/rung-github/src/lib.rs
@@ -26,5 +26,5 @@ pub use secrecy::SecretString;
 pub use rung_forge::{
     CheckRun, CheckStatus, CreateComment, CreatePullRequest, ForgeApi, ForgeError as Error,
     IssueComment, MergeMethod, MergePullRequest, MergeResult, PullRequest, PullRequestState,
-    Result, UpdateComment, UpdatePullRequest,
+    RepoId, Result, UpdateComment, UpdatePullRequest,
 };


### PR DESCRIPTION
## Summary

Introduces a forge-neutral `RepoId` to replace the GitHub-centric `owner: &str, repo: &str` parameters on `ForgeApi` (and the `owner`/`repo` fields on `RemoteInfo`). GitHub maps `owner/repo` onto it; a future GitLab backend can map nested namespace paths (`group/subgroup/project`) or numeric project IDs that an `owner`/`repo` pair cannot represent. Foundational groundwork for the GitLab `ForgeApi` impl (#170) and nested-path detection (#167). Fixes #165.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — N/A, no CLI command changes
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Refactor (internal forge abstraction; no user-facing behavior change)
- **Current behavior**: `ForgeApi` methods take `owner: &str, repo: &str`, and `RemoteInfo` exposes separate `owner`/`repo` `String` fields — GitHub vocabulary that cannot represent GitLab's nested project paths or numeric IDs.
- **New behavior**: A new `rung_forge::RepoId` (canonical project path; `new`/`path()`/`Display`, re-exported from `rung-github`) is threaded through `ForgeApi`, `RemoteInfo`, and `parse_remote`. The GitHub `impl ForgeApi` splits the `RepoId` back into `(owner, repo)` via `github_parts`, so `GitHubClient`'s inherent methods and on-wire requests are identical. CLI `Forge` dispatch, commands, and services carry a single `repo`/`repo_id` field in place of the owner/repo pair.
- **Breaking changes?**: No. Internal API only; GitHub behavior is unchanged.

## Other Information

- New unit tests for `RepoId`, the `github_parts` splitter (valid split, nested-path rejection, missing separator), and an end-to-end `ForgeApi`-level wiremock test verifying the adapter forwards the split `owner/repo` to the correct URL.
- Verified: `cargo test --workspace`, `cargo clippy --workspace --all-targets` (pedantic + nursery), `cargo fmt --check` all pass.
- Part of the GitLab support epic (#145).