### PR TITLE
refactor(forge): drive user-facing strings off ForgeKind

### DIFF
--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -170,7 +170,11 @@ pub fn run(
             .map_err(|_| {
                 forge_auth_unavailable = true;
                 if !json {
-                    output::warn("GitHub auth unavailable - skipping merge detection");
+                    let forge_name = rung_forge::ForgeKind::detect(url)
+                        .map_or("Forge", |kind| kind.display_name());
+                    output::warn(&format!(
+                        "{forge_name} auth unavailable - skipping merge detection"
+                    ));
                 }
             })
             .ok(),

--- a/crates/rung-cli/src/forge.rs
+++ b/crates/rung-cli/src/forge.rs
@@ -30,14 +30,19 @@ impl Forge {
     /// authentication for the detected forge fails.
     pub fn for_remote(remote_url: &str, auth: &Auth) -> Result<Self> {
         match ForgeKind::detect(remote_url) {
-            Some(ForgeKind::GitHub) => {
-                let client = GitHubClient::new(auth).context(
-                    "Failed to authenticate with GitHub - run `gh auth login` or set GITHUB_TOKEN",
-                )?;
+            Some(kind @ ForgeKind::GitHub) => {
+                let client = GitHubClient::new(auth).with_context(|| {
+                    format!(
+                        "Failed to authenticate with {} - {}",
+                        kind.display_name(),
+                        kind.auth_hint()
+                    )
+                })?;
                 Ok(Self::GitHub(client))
             }
             None => Err(anyhow!(
-                "unsupported forge: remote is not a recognized GitHub repository"
+                "unsupported forge: remote is not a recognized forge repository (supported: {})",
+                ForgeKind::supported_label()
             )),
         }
     }

--- a/crates/rung-cli/src/services/absorb.rs
+++ b/crates/rung-cli/src/services/absorb.rs
@@ -35,12 +35,18 @@ impl<'a, G: AbsorbOps> AbsorbService<'a, G> {
             .repo
             .origin_url()
             .context("No origin remote configured")?;
-        let rung_forge::RemoteInfo { repo: repo_id, .. } =
-            rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
+        let rung_forge::RemoteInfo {
+            repo: repo_id,
+            kind,
+        } = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
 
-        let client = Forge::for_remote(&origin_url, &Auth::auto()).context(
-            "GitHub auth required to detect default branch. Use --base <branch> to specify manually.",
-        )?;
+        let client = Forge::for_remote(&origin_url, &Auth::auto()).with_context(|| {
+            format!(
+                "{} auth required to detect default branch. \
+                 Use --base <branch> to specify manually.",
+                kind.display_name()
+            )
+        })?;
         client
             .get_default_branch(&repo_id)
             .await

--- a/crates/rung-cli/src/services/doctor.rs
+++ b/crates/rung-cli/src/services/doctor.rs
@@ -339,12 +339,15 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
             return result;
         };
 
-        let Ok(rung_forge::RemoteInfo { repo: repo_id, .. }) =
-            rung_forge::parse_remote(&origin_url)
+        let Ok(rung_forge::RemoteInfo {
+            repo: repo_id,
+            kind,
+        }) = rung_forge::parse_remote(&origin_url)
         else {
-            result
-                .issues
-                .push(Issue::warning("Origin is not a GitHub repository"));
+            result.issues.push(Issue::warning(format!(
+                "Origin is not a recognized repository (supported: {})",
+                rung_forge::ForgeKind::supported_label()
+            )));
             return result;
         };
 
@@ -352,8 +355,8 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
         let auth = Auth::auto();
         let Ok(client) = Forge::for_remote(&origin_url, &auth) else {
             result.issues.push(
-                Issue::error("GitHub authentication failed")
-                    .with_suggestion("Set GITHUB_TOKEN or authenticate with `gh auth login`"),
+                Issue::error(format!("{} authentication failed", kind.display_name()))
+                    .with_suggestion(kind.auth_hint()),
             );
             return result;
         };

--- a/crates/rung-forge/src/remote.rs
+++ b/crates/rung-forge/src/remote.rs
@@ -15,6 +15,41 @@ pub enum ForgeKind {
 }
 
 impl ForgeKind {
+    /// Every forge backend rung supports.
+    ///
+    /// Used to build user-facing "supported forges" hints in errors where no
+    /// specific forge was detected (see [`ForgeKind::supported_label`]).
+    pub const ALL: &'static [Self] = &[Self::GitHub];
+
+    /// Human-readable name of the forge, for user-facing messages.
+    #[must_use]
+    pub const fn display_name(self) -> &'static str {
+        match self {
+            Self::GitHub => "GitHub",
+        }
+    }
+
+    /// Hint describing how to authenticate with this forge, for error messages.
+    #[must_use]
+    pub const fn auth_hint(self) -> &'static str {
+        match self {
+            Self::GitHub => "run `gh auth login` or set GITHUB_TOKEN",
+        }
+    }
+
+    /// Comma-separated display names of every supported forge (e.g. `"GitHub"`).
+    ///
+    /// For "unrecognized remote" errors, where there is no detected forge to
+    /// name but listing the supported ones guides the user.
+    #[must_use]
+    pub fn supported_label() -> String {
+        Self::ALL
+            .iter()
+            .map(|kind| kind.display_name())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
     /// Detect the forge that hosts a git remote URL.
     ///
     /// Recognizes both HTTPS and SSH forms. Returns `None` if the host is not
@@ -91,6 +126,30 @@ fn parse_github(url: &str) -> Result<RemoteInfo> {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_display_name() {
+        assert_eq!(ForgeKind::GitHub.display_name(), "GitHub");
+    }
+
+    #[test]
+    fn test_auth_hint_mentions_credentials() {
+        let hint = ForgeKind::GitHub.auth_hint();
+        assert!(hint.contains("gh auth login"));
+        assert!(hint.contains("GITHUB_TOKEN"));
+    }
+
+    #[test]
+    fn test_supported_label_lists_all_kinds() {
+        let label = ForgeKind::supported_label();
+        for kind in ForgeKind::ALL {
+            assert!(
+                label.contains(kind.display_name()),
+                "supported_label {label:?} omits {}",
+                kind.display_name()
+            );
+        }
+    }
 
     #[test]
     fn test_detect_github_https() {


### PR DESCRIPTION
## Summary

Several auth/unsupported-remote messages hardcoded "GitHub" while backend selection was already generalized behind `ForgeKind`. This drives those user-facing strings off the detected `ForgeKind` so they stay correct once a second backend (GitLab) lands. Fixes #166.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — n/a, no CLI command changes
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Refactor (no behavior change for GitHub users)
- **Current behavior**: Error/warning strings hardcode "GitHub", "GITHUB_TOKEN", and "gh auth login" even though the forge backend is selected dynamically.
- **New behavior**: New `ForgeKind` methods — `display_name()`, `auth_hint()`, and `supported_label()` (+ `ALL`) — back the messages. Sites with a detected kind interpolate it; "unrecognized remote" sites list the supported forges. The `match` has a single GitHub arm today; the GitLab arm slots in with `ForgeKind::GitLab` (#167).

  Sites updated:
  - `forge.rs`: auth-fail context + unsupported-remote error
  - `sync.rs`: "auth unavailable - skipping merge detection" warning
  - `doctor.rs`: parse-fail warning + auth-fail error/suggestion
  - `absorb.rs`: default-branch auth-required context
- **Breaking changes?**: No.