### PR TITLE
feat(gitlab): scaffold rung-gitlab crate with authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,11 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+      - name: Publish rung-gitlab
+        run: cargo publish -p rung-gitlab
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
       - name: Publish rung-cli
         run: cargo publish -p rung-cli
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rung-core = { version = "0.9.0", path = "crates/rung-core" }
 rung-forge = { version = "0.9.0", path = "crates/rung-forge" }
 rung-git = { version = "0.9.0", path = "crates/rung-git" }
 rung-github = { version = "0.9.0", path = "crates/rung-github" }
+rung-gitlab = { version = "0.9.0", path = "crates/rung-gitlab" }
 
 # Git operations
 git2 = "0.19"
@@ -94,3 +95,8 @@ replace = 'rung-git = { version = "{{version}}"'
 file = "Cargo.toml"
 search = 'rung-github = \{ version = "[^"]*"'
 replace = 'rung-github = { version = "{{version}}"'
+
+[[workspace.metadata.release.pre-release-replacements]]
+file = "Cargo.toml"
+search = 'rung-gitlab = \{ version = "[^"]*"'
+replace = 'rung-gitlab = { version = "{{version}}"'

--- a/crates/rung-gitlab/Cargo.toml
+++ b/crates/rung-gitlab/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rung-gitlab"
+description = "GitLab API integration for Rung - merge request management and CI status"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+readme = "README.md"
+keywords = ["gitlab", "api", "merge-request"]
+categories = ["development-tools", "api-bindings"]
+
+[dependencies]
+rung-forge = { workspace = true }
+reqwest = { workspace = true }
+secrecy = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+wiremock = "0.6"
+
+[lints]
+workspace = true

--- a/crates/rung-gitlab/README.md
+++ b/crates/rung-gitlab/README.md
@@ -1,0 +1,14 @@
+# rung-gitlab
+
+GitLab authentication and API client scaffolding for [rung](https://github.com/auswm85/rung).
+Merge request and CI operations are not implemented yet.
+
+This crate is primarily intended for internal use by the rung CLI. For general usage, install the CLI directly:
+
+```bash
+cargo install rung-cli
+```
+
+## License
+
+MIT

--- a/crates/rung-gitlab/src/auth.rs
+++ b/crates/rung-gitlab/src/auth.rs
@@ -1,0 +1,140 @@
+//! Authentication handling for the GitLab API.
+//!
+//! Tokens are stored using `SecretString` from the `secrecy` crate, which
+//! automatically zeroizes memory when dropped and prevents accidental logging.
+//!
+//! Mirrors [`rung_github::Auth`] so both forges resolve credentials the same
+//! way: an environment variable first, then the forge's own CLI.
+
+use std::process::Command;
+
+#[cfg(test)]
+use secrecy::ExposeSecret;
+use secrecy::SecretString;
+
+use rung_forge::{ForgeError as Error, Result};
+
+/// Default GitLab host the `glab` CLI stores credentials under.
+///
+/// Self-hosted instances are handled separately (see issue #172); for now the
+/// CLI fallback always targets `gitlab.com`.
+const DEFAULT_GLAB_HOST: &str = "gitlab.com";
+
+/// Authentication method for the GitLab API.
+#[derive(Debug, Clone)]
+pub enum Auth {
+    /// Use the token stored by the `glab` CLI.
+    GlabCli,
+
+    /// Use a token from the named environment variable.
+    EnvVar(String),
+
+    /// Use a specific token (zeroized on drop).
+    Token(SecretString),
+}
+
+impl Auth {
+    /// Create auth from the first available method.
+    ///
+    /// Tries in order: `GITLAB_TOKEN` env var, then the `glab` CLI.
+    ///
+    /// A blank or whitespace-only `GITLAB_TOKEN` is ignored so it cannot mask a
+    /// usable `glab` credential.
+    #[must_use]
+    pub fn auto() -> Self {
+        match std::env::var("GITLAB_TOKEN") {
+            Ok(token) if !token.trim().is_empty() => Self::EnvVar("GITLAB_TOKEN".into()),
+            _ => Self::GlabCli,
+        }
+    }
+
+    /// Resolve the authentication to a token string.
+    ///
+    /// Returns a `SecretString` that will be zeroized when dropped.
+    ///
+    /// # Errors
+    /// Returns [`ForgeError::NoToken`] if no token can be obtained.
+    ///
+    /// [`ForgeError::NoToken`]: rung_forge::ForgeError::NoToken
+    pub fn resolve(&self) -> Result<SecretString> {
+        match self {
+            Self::GlabCli => get_glab_token(),
+            Self::EnvVar(var) => {
+                let token = std::env::var(var).map_err(|_| Error::NoToken)?;
+                let token = token.trim();
+                if token.is_empty() {
+                    return Err(Error::NoToken);
+                }
+                Ok(SecretString::from(token))
+            }
+            Self::Token(t) => Ok(t.clone()),
+        }
+    }
+}
+
+impl Default for Auth {
+    fn default() -> Self {
+        Self::auto()
+    }
+}
+
+/// Get the GitLab token stored by the `glab` CLI.
+///
+/// Unlike `gh`, the `glab` CLI has no `auth token` subcommand; the stored token
+/// is read with `glab config get token --host <host>`, which prints only the
+/// value (or nothing if it is unset).
+///
+/// A missing `glab` binary is treated as "no credential source" ([`Error::NoToken`])
+/// rather than an I/O error, matching the [`Auth::resolve`] contract.
+fn get_glab_token() -> Result<SecretString> {
+    let output = Command::new("glab")
+        .args(["config", "get", "token", "--host", DEFAULT_GLAB_HOST])
+        .output()
+        .map_err(|_| Error::NoToken)?;
+
+    if !output.status.success() {
+        return Err(Error::NoToken);
+    }
+
+    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    if token.is_empty() {
+        return Err(Error::NoToken);
+    }
+
+    Ok(SecretString::from(token))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auth_auto_does_not_panic() {
+        // Depends on the environment, so just ensure it resolves to a variant.
+        let _auth = Auth::auto();
+    }
+
+    #[test]
+    fn test_token_auth_resolves_to_value() {
+        let auth = Auth::Token(SecretString::from("glpat-test-token"));
+        assert_eq!(auth.resolve().unwrap().expose_secret(), "glpat-test-token");
+    }
+
+    #[test]
+    fn test_env_var_auth_missing_is_error() {
+        // A unique var name that is extremely unlikely to exist.
+        let auth = Auth::EnvVar("RUNG_TEST_NONEXISTENT_VAR_9a8b7c6d5e4f".into());
+        assert!(auth.resolve().is_err());
+    }
+
+    #[test]
+    fn test_auth_default_is_auto() {
+        // Default must never be a bare Token; it picks env var or CLI.
+        match Auth::default() {
+            Auth::GlabCli | Auth::EnvVar(_) => {}
+            Auth::Token(_) => panic!("Default should not return Token"),
+        }
+    }
+}

--- a/crates/rung-gitlab/src/client.rs
+++ b/crates/rung-gitlab/src/client.rs
@@ -1,0 +1,298 @@
+//! GitLab API client.
+//!
+//! This is the credential-bearing foundation for GitLab support: it resolves an
+//! [`Auth`] to a token and builds an authenticated HTTP client. It carries a
+//! skeleton [`ForgeApi`](rung_forge::ForgeApi) implementation; the merge
+//! request, pipeline, and comment methods are filled in separately (see issue
+//! #170).
+
+use std::collections::HashMap;
+
+use reqwest::Client;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+
+use rung_forge::{
+    CheckRun, CreateComment, CreatePullRequest, ForgeApi, ForgeError as Error, IssueComment,
+    MergePullRequest, MergeResult, PullRequest, RepoId, Result, UpdateComment, UpdatePullRequest,
+};
+
+use crate::auth::Auth;
+
+/// The authenticated GitLab user, returned by `GET /user`.
+///
+/// Used to verify that resolved credentials are valid.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitLabUser {
+    /// Numeric user ID.
+    pub id: u64,
+    /// Account username (the `@handle`).
+    pub username: String,
+}
+
+/// GitLab API client.
+///
+/// Holds an authenticated [`reqwest::Client`] and the API base URL. The token
+/// is stored as a [`SecretString`] so it is zeroized on drop and never logged.
+pub struct GitLabClient {
+    client: Client,
+    base_url: String,
+    /// Token stored as `SecretString` for automatic zeroization on drop.
+    token: SecretString,
+}
+
+impl GitLabClient {
+    /// Default GitLab API base URL (gitlab.com, REST v4).
+    ///
+    /// Self-hosted instances supply their own base URL (see issue #172).
+    pub const DEFAULT_API_URL: &'static str = "https://gitlab.com/api/v4";
+
+    /// Create a new GitLab client targeting gitlab.com.
+    ///
+    /// # Errors
+    /// Returns an error if authentication cannot be resolved or the HTTP client
+    /// cannot be built.
+    pub fn new(auth: &Auth) -> Result<Self> {
+        Self::with_base_url(auth, Self::DEFAULT_API_URL)
+    }
+
+    /// Create a new GitLab client with a custom API base URL.
+    ///
+    /// Used for self-hosted instances and for tests pointing at a mock server.
+    ///
+    /// # Errors
+    /// Returns an error if authentication cannot be resolved or the HTTP client
+    /// cannot be built.
+    pub fn with_base_url(auth: &Auth, base_url: impl Into<String>) -> Result<Self> {
+        let token = auth.resolve()?;
+
+        // Normalize so a custom base URL with a trailing slash (common for
+        // self-hosted instances) does not produce `.../api/v4//user`.
+        let base_url = base_url.into().trim_end_matches('/').to_owned();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static("rung-cli"));
+
+        let client = Client::builder()
+            .default_headers(headers)
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
+
+        Ok(Self {
+            client,
+            base_url,
+            token,
+        })
+    }
+
+    /// Fetch the authenticated user, verifying the resolved credentials.
+    ///
+    /// # Errors
+    /// Returns [`Error::AuthenticationFailed`] if the token is rejected, or an
+    /// [`Error::ApiError`] for other non-success responses.
+    pub async fn current_user(&self) -> Result<GitLabUser> {
+        self.get("/user").await
+    }
+
+    /// Make an authenticated GET request and deserialize the JSON body.
+    async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let url = format!("{}{path}", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .header(
+                AUTHORIZATION,
+                format!("Bearer {}", self.token.expose_secret()),
+            )
+            .send()
+            .await?;
+
+        let status = response.status();
+        if status.is_success() {
+            return Ok(response.json().await?);
+        }
+
+        match status.as_u16() {
+            401 => Err(Error::AuthenticationFailed),
+            429 => Err(Error::RateLimited),
+            code => {
+                let message = response.text().await.unwrap_or_default();
+                Err(Error::ApiError {
+                    status: code,
+                    message,
+                })
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for GitLabClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GitLabClient")
+            .field("base_url", &self.base_url)
+            .field("token", &"[redacted]")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Skeleton [`ForgeApi`] implementation.
+///
+/// Every method is currently `unimplemented!()`; the real GitLab merge-request,
+/// pipeline, and comment logic is added in issue #170. The impl exists now so
+/// the CLI can dispatch to GitLab through the forge-neutral trait (issue #171)
+/// once those methods are filled in.
+#[allow(clippy::unused_async)]
+impl ForgeApi for GitLabClient {
+    async fn get_pr(&self, _repo: &RepoId, _number: u64) -> Result<PullRequest> {
+        unimplemented!("GitLab get_pr: see #170")
+    }
+
+    async fn get_prs_batch(
+        &self,
+        _repo: &RepoId,
+        _numbers: &[u64],
+    ) -> Result<HashMap<u64, PullRequest>> {
+        unimplemented!("GitLab get_prs_batch: see #170")
+    }
+
+    async fn find_pr_for_branch(
+        &self,
+        _repo: &RepoId,
+        _branch: &str,
+    ) -> Result<Option<PullRequest>> {
+        unimplemented!("GitLab find_pr_for_branch: see #170")
+    }
+
+    async fn create_pr(&self, _repo: &RepoId, _pr: CreatePullRequest) -> Result<PullRequest> {
+        unimplemented!("GitLab create_pr: see #170")
+    }
+
+    async fn update_pr(
+        &self,
+        _repo: &RepoId,
+        _number: u64,
+        _update: UpdatePullRequest,
+    ) -> Result<PullRequest> {
+        unimplemented!("GitLab update_pr: see #170")
+    }
+
+    async fn get_check_runs(&self, _repo: &RepoId, _commit_sha: &str) -> Result<Vec<CheckRun>> {
+        unimplemented!("GitLab get_check_runs: see #170")
+    }
+
+    async fn merge_pr(
+        &self,
+        _repo: &RepoId,
+        _number: u64,
+        _merge: MergePullRequest,
+    ) -> Result<MergeResult> {
+        unimplemented!("GitLab merge_pr: see #170")
+    }
+
+    async fn delete_ref(&self, _repo: &RepoId, _ref_name: &str) -> Result<()> {
+        unimplemented!("GitLab delete_ref: see #170")
+    }
+
+    async fn get_default_branch(&self, _repo: &RepoId) -> Result<String> {
+        unimplemented!("GitLab get_default_branch: see #170")
+    }
+
+    async fn list_pr_comments(&self, _repo: &RepoId, _pr_number: u64) -> Result<Vec<IssueComment>> {
+        unimplemented!("GitLab list_pr_comments: see #170")
+    }
+
+    async fn create_pr_comment(
+        &self,
+        _repo: &RepoId,
+        _pr_number: u64,
+        _comment: CreateComment,
+    ) -> Result<IssueComment> {
+        unimplemented!("GitLab create_pr_comment: see #170")
+    }
+
+    async fn update_pr_comment(
+        &self,
+        _repo: &RepoId,
+        _comment_id: u64,
+        _comment: UpdateComment,
+    ) -> Result<IssueComment> {
+        unimplemented!("GitLab update_pr_comment: see #170")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use secrecy::SecretString;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn test_client(base_url: &str) -> GitLabClient {
+        let auth = Auth::Token(SecretString::from("glpat-test-token"));
+        GitLabClient::with_base_url(&auth, base_url).unwrap()
+    }
+
+    #[test]
+    fn test_debug_redacts_token() {
+        let client = test_client("https://gitlab.example.com/api/v4");
+        let debug = format!("{client:?}");
+        assert!(debug.contains("base_url"));
+        assert!(debug.contains("[redacted]"));
+        assert!(!debug.contains("glpat-test-token"));
+    }
+
+    #[tokio::test]
+    async fn test_current_user_sends_bearer_token() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/user"))
+            .and(header("authorization", "Bearer glpat-test-token"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"id": 42, "username": "octocat"})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri());
+        let user = client.current_user().await.unwrap();
+
+        assert_eq!(user.id, 42);
+        assert_eq!(user.username, "octocat");
+    }
+
+    #[tokio::test]
+    async fn test_trailing_slash_base_url_does_not_double_slash() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/user"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"id": 1, "username": "u"})),
+            )
+            .mount(&server)
+            .await;
+
+        // A base URL with a trailing slash must still hit `/user`, not `//user`.
+        let client = test_client(&format!("{}/", server.uri()));
+        assert!(client.current_user().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_current_user_maps_401_to_auth_failed() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/user"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri());
+        let err = client.current_user().await.unwrap_err();
+
+        assert!(matches!(err, Error::AuthenticationFailed));
+    }
+}

--- a/crates/rung-gitlab/src/lib.rs
+++ b/crates/rung-gitlab/src/lib.rs
@@ -1,0 +1,32 @@
+//! # rung-gitlab
+//!
+//! GitLab API integration for Rung, providing merge request management and CI
+//! status fetching capabilities.
+//!
+//! # Architecture
+//!
+//! This crate provides the concrete [`GitLabClient`], which implements the
+//! [`ForgeApi`] trait defined in the `rung-forge` contract crate. The forge
+//! types and trait are re-exported here for convenience. Authentication and the
+//! credential-bearing HTTP client are functional today; the merge-request,
+//! pipeline, and comment methods are currently skeletons (see issue #170).
+//!
+//! # Security
+//!
+//! Authentication tokens are stored using `SecretString`, which automatically
+//! zeroizes memory when dropped, reducing credential exposure in memory dumps.
+
+mod auth;
+mod client;
+
+pub use auth::Auth;
+pub use client::{GitLabClient, GitLabUser};
+// Re-export SecretString for constructing `Auth::Token`.
+pub use secrecy::SecretString;
+// Re-export the forge contract so `rung_gitlab::{...}` mirrors `rung_github`.
+// `ForgeError` is re-exported as `Error` for parity with the GitHub crate.
+pub use rung_forge::{
+    CheckRun, CheckStatus, CreateComment, CreatePullRequest, ForgeApi, ForgeError as Error,
+    IssueComment, MergeMethod, MergePullRequest, MergeResult, PullRequest, PullRequestState,
+    RepoId, Result, UpdateComment, UpdatePullRequest,
+};


### PR DESCRIPTION
## Summary

Scaffolds the new `rung-gitlab` crate and implements GitLab authentication, mirroring how `rung-github` depends on `rung-forge`. This is the credential-bearing foundation for GitLab support; the real `ForgeApi` method bodies (#170) and CLI wiring (#171) follow.

Closes #168, #169. Refs #145, #170, #171.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — N/A (no CLI commands), crate `README.md` added
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Feature (new crate + authentication)
- **Current behavior**: Rung only supports GitHub; there is no GitLab crate or credential handling.
- **New behavior**:
  - New `crates/rung-gitlab` crate wired into `[workspace.dependencies]`, the `release.yml` publish order (after `rung-github`), and the release version-bump replacements.
  - `Auth` resolves credentials in order: `GITLAB_TOKEN` env var → `glab` CLI. Tokens are held as a zeroized `SecretString`.
  - `GitLabClient::new` / `with_base_url` build an authenticated `reqwest` client (Bearer auth) against the gitlab.com REST v4 API. A custom base URL is accepted for self-hosted instances (#172) and tests.
  - `current_user()` verifies resolved credentials; covered by `wiremock` tests (bearer header is sent; `401` → `AuthenticationFailed`).
  - Skeleton `impl ForgeApi for GitLabClient` with `unimplemented!()` bodies, so the CLI can dispatch through the forge-neutral trait once the methods land (#170/#171).
- **Breaking changes?**: No. Purely additive — the new crate is not yet wired into `rung-cli`.

## Other Information

**Deviation from #169 worth flagging:** the issue says to use a `glab auth token` fallback, but `glab` has no `auth token` subcommand (unlike `gh auth token`). The stored token is instead read via `glab config get token --host gitlab.com`, which prints only the value (empty if unset). Hostname is hardcoded to `gitlab.com` for now; self-hosted hosts are tracked in #172.

This PR also absorbs the #168 scaffolding (crate creation + workspace/release wiring + `ForgeApi` skeleton) since #169's auth work cannot land without the crate existing — so it closes both.
