### PR TITLE
docs: reflect rung-forge/rung-gitlab in crate structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,9 @@ crates/
   rung-cli/      # Command-line interface
   rung-core/     # Core logic (stack, sync, state)
   rung-git/      # Git operations wrapper
-  rung-github/   # GitHub API client
+  rung-forge/    # Forge-neutral contract (ForgeApi trait, remote detection)
+  rung-github/   # GitHub backend
+  rung-gitlab/   # GitLab backend (in progress)
 ```
 
 ## Development

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,8 +38,8 @@ Rung is a two-component system:
 │  └───────┬─────────────────────────────────────┬───────────┘   │
 │          │                                     │                │
 │  ┌───────▼───────┐                   ┌────────▼────────┐       │
-│  │   rung-git    │                   │   rung-github   │       │
-│  │  git2-rs ops  │                   │   PR API calls  │       │
+│  │   rung-git    │                   │   rung-forge    │       │
+│  │  git2-rs ops  │                   │  ForgeApi+impls │       │
 │  └───────────────┘                   └─────────────────┘       │
 └─────────────────────────────────────────────────────────────────┘
                             │
@@ -49,6 +49,10 @@ Rung is a two-component system:
 │       .git/rung/ (stack.json | config.toml | refs/)             │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+`rung-forge` defines the forge-neutral `ForgeApi` contract; `rung-github` (and
+the in-progress `rung-gitlab`) implement it. The CLI selects a backend from the
+detected git remote.
 
 ---
 
@@ -78,13 +82,28 @@ rung/
 │   │   │   └── notes.rs          # Git Notes integration
 │   │   └── Cargo.toml
 │   │
-│   ├── rung-github/              # GitHub API
+│   ├── rung-forge/              # Forge-neutral contract
 │   │   ├── src/
 │   │   │   ├── lib.rs
-│   │   │   ├── client.rs         # HTTP client
-│   │   │   ├── pr.rs             # PR CRUD
-│   │   │   ├── checks.rs         # CI status
-│   │   │   └── auth.rs           # gh CLI / OAuth
+│   │   │   ├── traits.rs         # ForgeApi trait
+│   │   │   ├── types.rs          # PR/comment/check domain types
+│   │   │   ├── repo_id.rs        # Forge-neutral RepoId
+│   │   │   ├── remote.rs         # ForgeKind remote detection
+│   │   │   └── error.rs          # Neutral error types
+│   │   └── Cargo.toml
+│   │
+│   ├── rung-github/              # GitHub backend
+│   │   ├── src/
+│   │   │   ├── lib.rs
+│   │   │   ├── client.rs         # HTTP client + ForgeApi impl
+│   │   │   └── auth.rs           # gh CLI / GITHUB_TOKEN
+│   │   └── Cargo.toml
+│   │
+│   ├── rung-gitlab/              # GitLab backend (in progress)
+│   │   ├── src/
+│   │   │   ├── lib.rs
+│   │   │   ├── client.rs         # HTTP client + ForgeApi (stubbed, #170)
+│   │   │   └── auth.rs           # glab CLI / GITLAB_TOKEN
 │   │   └── Cargo.toml
 │   │
 │   └── rung-cli/                 # CLI application
@@ -111,11 +130,17 @@ rung/
 ```
 rung-cli
     ├── rung-core
-    │   ├── rung-git
-    │   └── rung-github
+    │   └── rung-git
+    ├── rung-git
+    ├── rung-forge              # ForgeApi trait, RepoId, ForgeKind detection
+    ├── rung-github             # GitHub backend
+    │   └── rung-forge
     └── clap (CLI parsing)
          tokio (async runtime)
          serde_json (output)
+
+rung-gitlab                     # GitLab backend (implements rung-forge); CLI wiring pending (#171)
+    └── rung-forge
 ```
 
 ---
@@ -474,17 +499,17 @@ class LadderTreeProvider implements vscode.TreeDataProvider<BranchNode> {
       case "synced":
         return new vscode.ThemeIcon(
           "check",
-          new vscode.ThemeColor("charts.green")
+          new vscode.ThemeColor("charts.green"),
         );
       case "diverged":
         return new vscode.ThemeIcon(
           "warning",
-          new vscode.ThemeColor("charts.yellow")
+          new vscode.ThemeColor("charts.yellow"),
         );
       case "conflict":
         return new vscode.ThemeIcon(
           "error",
-          new vscode.ThemeColor("charts.red")
+          new vscode.ThemeColor("charts.red"),
         );
       default:
         return new vscode.ThemeIcon("git-branch");
@@ -729,24 +754,20 @@ tests/
 ### 9.2 Key Test Scenarios
 
 1. **Linear Stack Sync**
-
    - Create 3-branch stack
    - Add commit to base
    - Sync: verify all branches rebased
 
 2. **Mid-Stack Conflict**
-
    - Create conflicting changes
    - Sync: verify pause at conflict
    - Resolve, continue: verify completion
 
 3. **Undo After Partial Sync**
-
    - Sync with conflict at branch 2/3
    - Undo: verify all branches restored
 
 4. **Branch Rename Detection**
-
    - Rename branch via `git branch -m`
    - Verify rung detects via reflog
    - Update metadata automatically
@@ -804,7 +825,7 @@ pub enum RungError {
 
 ### Phase 2 Features (Not in MVP)
 
-1. **GitLab Support**: Abstract `rung-github` to `rung-forge` with GitLab impl
+1. **GitLab Support**: The `rung-forge` contract and `rung-gitlab` backend (auth + client scaffold) exist; remaining work is the `ForgeApi` implementation (#170) and CLI wiring (#171)
 2. **Multi-Root Stacks**: Allow branch to depend on multiple parents
 3. **Auto-Sync**: Watch for upstream changes, notify user
 4. **Team Collaboration**: Shared stacks across team members


### PR DESCRIPTION
## Summary

Updates the repo's architecture documentation to reflect the current workspace structure. The forge-neutral contract crate (`rung-forge`, extracted in #162) and the GitLab backend (`rung-gitlab`, added in #176) both predated these docs, which still described a four-crate, GitHub-only layout.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally — N/A (docs-only change, no code touched)
- [ ] I have added/updated tests for these changes — N/A (docs-only)
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — crate tree updated
- [x] **Documentation**: I have added doc comments (`///`) to new public functions — N/A (docs-only)

## Change Description

- **Type of change**: Documentation
- **Current behavior**: `README.md` and `docs/architecture.md` describe a four-crate workspace (`rung-cli`, `rung-core`, `rung-git`, `rung-github`) and omit the forge abstraction.
- **New behavior**:
  - **README**: crate tree now lists `rung-forge` (forge-neutral contract) and `rung-gitlab` (GitLab backend, in progress).
  - **architecture.md**: component diagram shows the forge contract layer; the file tree adds both crates with their actual modules; the dependency tree is corrected (`rung-github`/`rung-gitlab` depend on `rung-forge`, and `rung-gitlab` is not yet wired into the CLI); the GitLab "future" note now reflects that the abstraction has shipped, with remaining work tracked in #170 (ForgeApi impl) and #171 (CLI wiring).
- **Breaking changes?**: No.

## Other Information

**Scope deliberately limited to internal/architecture docs.** User-facing "GitHub-only" docs (the `site/` content, FAQ's "Does rung work with GitLab?", installation/auth guides) are intentionally left unchanged because GitLab is not usable end-to-end until #170/#171 land — those should be updated in the PR that makes it usable.

`CLAUDE.md` and `.serena/` were also refreshed locally to match, but they are gitignored in this repo so they are not part of this PR.
