### PR TITLE
refactor(github): update PR comment method to include pr_number

### DIFF
--- a/crates/rung-cli/src/forge.rs
+++ b/crates/rung-cli/src/forge.rs
@@ -153,11 +153,14 @@ impl ForgeApi for Forge {
     async fn update_pr_comment(
         &self,
         repo: &RepoId,
+        pr_number: u64,
         comment_id: u64,
         comment: UpdateComment,
     ) -> ForgeResult<IssueComment> {
         match self {
-            Self::GitHub(c) => ForgeApi::update_pr_comment(c, repo, comment_id, comment).await,
+            Self::GitHub(c) => {
+                ForgeApi::update_pr_comment(c, repo, pr_number, comment_id, comment).await
+            }
         }
     }
 }

--- a/crates/rung-cli/src/services/merge.rs
+++ b/crates/rung-cli/src/services/merge.rs
@@ -914,6 +914,7 @@ mod tests {
             fn update_pr_comment(
                 &self,
                 _repo: &rung_github::RepoId,
+                _pr_number: u64,
                 _comment_id: u64,
                 _comment: rung_github::UpdateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send

--- a/crates/rung-cli/src/services/submit.rs
+++ b/crates/rung-cli/src/services/submit.rs
@@ -357,7 +357,7 @@ where
             if let Some(comment) = existing_comment {
                 let update = UpdateComment { body: comment_body };
                 self.github
-                    .update_pr_comment(&self.repo, comment.id, update)
+                    .update_pr_comment(&self.repo, pr_number, comment.id, update)
                     .await
                     .with_context(|| format!("Failed to update comment on PR #{pr_number}"))?;
             } else {
@@ -1225,6 +1225,7 @@ mod tests {
             fn update_pr_comment(
                 &self,
                 _repo: &rung_github::RepoId,
+                _pr_number: u64,
                 _comment_id: u64,
                 _comment: rung_github::UpdateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send

--- a/crates/rung-cli/src/services/sync.rs
+++ b/crates/rung-cli/src/services/sync.rs
@@ -753,6 +753,7 @@ mod tests {
             fn update_pr_comment(
                 &self,
                 _repo: &rung_github::RepoId,
+                _pr_number: u64,
                 _comment_id: u64,
                 _comment: rung_github::UpdateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send
@@ -1074,6 +1075,7 @@ mod tests {
             fn update_pr_comment(
                 &self,
                 _repo: &rung_github::RepoId,
+                _pr_number: u64,
                 _comment_id: u64,
                 _comment: rung_github::UpdateComment,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::IssueComment>> + Send

--- a/crates/rung-forge/src/traits.rs
+++ b/crates/rung-forge/src/traits.rs
@@ -118,9 +118,14 @@ pub trait ForgeApi: Send + Sync {
     ) -> impl std::future::Future<Output = Result<IssueComment>> + Send;
 
     /// Update a comment on a pull request.
+    ///
+    /// `pr_number` identifies the pull/merge request the comment belongs to.
+    /// GitHub addresses comments by id alone and ignores it, but GitLab scopes
+    /// note updates to the merge request, so the contract carries it for both.
     fn update_pr_comment(
         &self,
         repo: &RepoId,
+        pr_number: u64,
         comment_id: u64,
         comment: UpdateComment,
     ) -> impl std::future::Future<Output = Result<IssueComment>> + Send;

--- a/crates/rung-github/src/client.rs
+++ b/crates/rung-github/src/client.rs
@@ -805,9 +805,12 @@ impl ForgeApi for GitHubClient {
     async fn update_pr_comment(
         &self,
         repo: &RepoId,
+        _pr_number: u64,
         comment_id: u64,
         comment: UpdateComment,
     ) -> Result<IssueComment> {
+        // GitHub updates a comment by id alone (`/issues/comments/:id`), so the
+        // PR number the forge-neutral contract carries (for GitLab) is unused.
         let (owner, name) = github_parts(repo)?;
         self.update_pr_comment(owner, name, comment_id, comment)
             .await

--- a/crates/rung-gitlab/src/client.rs
+++ b/crates/rung-gitlab/src/client.rs
@@ -214,6 +214,7 @@ impl ForgeApi for GitLabClient {
     async fn update_pr_comment(
         &self,
         _repo: &RepoId,
+        _pr_number: u64,
         _comment_id: u64,
         _comment: UpdateComment,
     ) -> Result<IssueComment> {


### PR DESCRIPTION
## Summary

Threads a `pr_number` argument through `ForgeApi::update_pr_comment`. This is preparatory groundwork for the GitLab `ForgeApi` implementation (#170) — it does not close an issue on its own.

GitLab scopes note updates to the merge request (`PUT /projects/:id/merge_requests/:iid/notes/:note_id`), so the forge-neutral trait must carry the PR/MR number. GitHub addresses comments by id alone and ignores the new argument.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes — covered by existing GitHub client and CLI service tests, updated for the new signature
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — N/A, no CLI commands changed
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Refactor
- **Current behavior**: `update_pr_comment(repo, comment_id, comment)` — no PR/MR number.
- **New behavior**: `update_pr_comment(repo, pr_number, comment_id, comment)`. The GitHub backend ignores `pr_number`; the GitLab backend (#170) needs it to address the note's merge request.
- **Breaking changes?**: Yes — to the `rung-forge` `ForgeApi` trait (pre-1.0). Implementors add a `pr_number: u64` parameter to `update_pr_comment`. All in-tree implementors and call sites are updated in this PR.

## Other Information

Base of the stack for #170 (PR #180 targets this branch).
