### PR TITLE
feat(gitlab): wire GitLab backend into the CLI Forge factory

### DIFF
--- a/crates/rung-cli/Cargo.toml
+++ b/crates/rung-cli/Cargo.toml
@@ -31,6 +31,7 @@ rung-core = { workspace = true }
 rung-forge = { workspace = true }
 rung-git = { workspace = true }
 rung-github = { workspace = true }
+rung-gitlab = { workspace = true }
 
 chrono = { workspace = true }
 clap = { workspace = true }

--- a/crates/rung-cli/src/commands/merge.rs
+++ b/crates/rung-cli/src/commands/merge.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, bail};
 use rung_core::State;
 use rung_core::stack::Stack;
 use rung_git::{Oid, Repository};
-use rung_github::{Auth, MergeMethod, RepoId};
+use rung_github::{MergeMethod, RepoId};
 
 use crate::forge::Forge;
 use serde::Serialize;
@@ -190,9 +190,8 @@ async fn execute_merge(
     no_delete: bool,
     json: bool,
 ) -> Result<(String, usize)> {
-    let auth = Auth::auto();
     let origin_url = repo.origin_url()?;
-    let client = Forge::for_remote(&origin_url, &auth)?;
+    let client = Forge::for_remote(&origin_url)?;
     let service = MergeService::new(repo, &client, ctx.repo_id.clone());
 
     // Step 1: Validate PR is mergeable

--- a/crates/rung-cli/src/commands/status.rs
+++ b/crates/rung-cli/src/commands/status.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use rung_core::State;
 use rung_git::Repository;
-use rung_github::{Auth, ForgeApi, PullRequestState};
+use rung_github::{ForgeApi, PullRequestState};
 
 use crate::forge::Forge;
 use serde::Serialize;
@@ -124,7 +124,7 @@ fn fetch_pr_statuses(
     let rung_forge::RemoteInfo { repo: repo_id, .. } =
         rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
 
-    let client = Forge::for_remote(&origin_url, &Auth::auto())?;
+    let client = Forge::for_remote(&origin_url)?;
     let rt = tokio::runtime::Runtime::new()?;
 
     if !json {

--- a/crates/rung-cli/src/commands/submit.rs
+++ b/crates/rung-cli/src/commands/submit.rs
@@ -4,7 +4,6 @@ use anyhow::{Context, Result, bail};
 use inquire::{Select, Text};
 use rung_core::{State, stack::Stack, sync};
 use rung_git::{RemoteDivergence, Repository};
-use rung_github::Auth;
 
 use crate::forge::Forge;
 use serde::Serialize;
@@ -109,7 +108,7 @@ pub fn run(
     let repo_id = get_remote_info(&repo)?;
 
     let origin_url = repo.origin_url().context("No origin remote configured")?;
-    let client = Forge::for_remote(&origin_url, &Auth::auto())?;
+    let client = Forge::for_remote(&origin_url)?;
     let rt = tokio::runtime::Runtime::new()?;
 
     let service = SubmitService::new(&repo, &client, repo_id.clone());

--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -13,7 +13,7 @@ use rung_core::sync::{
     self, ReconcileResult, SyncConflictPrediction, SyncResult, predict_sync_conflicts,
 };
 use rung_git::Repository;
-use rung_github::{Auth, ForgeApi, RepoId};
+use rung_github::{ForgeApi, RepoId};
 use serde::Serialize;
 
 use crate::forge::Forge;
@@ -166,20 +166,15 @@ pub fn run(
     // Create the forge client (if available)
     let mut forge_auth_unavailable = false;
     let client = match (forge_info.as_ref(), origin_url.as_deref()) {
-        (Some(_), Some(url)) => Forge::for_remote(url, &Auth::auto())
+        (Some(_), Some(url)) => Forge::for_remote(url)
             .map_err(|_| {
                 forge_auth_unavailable = true;
                 if !json {
-                    let kind = rung_forge::ForgeKind::detect(url);
-                    // GitLab parses but isn't wired into the CLI yet (#171);
-                    // say so rather than implying an auth problem.
-                    let reason = if kind == Some(rung_forge::ForgeKind::GitLab) {
-                        "not yet supported by the CLI"
-                    } else {
-                        "auth unavailable"
-                    };
-                    let forge_name = kind.map_or("Forge", |kind| kind.display_name());
-                    output::warn(&format!("{forge_name} {reason} - skipping merge detection"));
+                    let forge_name = rung_forge::ForgeKind::detect(url)
+                        .map_or("Forge", |kind| kind.display_name());
+                    output::warn(&format!(
+                        "{forge_name} auth unavailable - skipping merge detection"
+                    ));
                 }
             })
             .ok(),
@@ -207,9 +202,10 @@ pub fn run(
 /// Used to annotate `--json` output: `true` only when there is a recognized
 /// forge remote but a client for it cannot be constructed (auth failure).
 fn forge_auth_unavailable(repo: &Repository) -> bool {
-    repo.origin_url().ok().as_deref().is_some_and(|url| {
-        rung_forge::parse_remote(url).is_ok() && Forge::for_remote(url, &Auth::auto()).is_err()
-    })
+    repo.origin_url()
+        .ok()
+        .as_deref()
+        .is_some_and(|url| rung_forge::parse_remote(url).is_ok() && Forge::for_remote(url).is_err())
 }
 
 /// Handle --abort flag.
@@ -273,7 +269,7 @@ fn determine_base_branch(
                 "Could not detect forge remote (unsupported URL). Use --base <branch> to specify manually."
             )
         })?;
-    let client = Forge::for_remote(url, &Auth::auto()).context(
+    let client = Forge::for_remote(url).context(
         "Forge auth required to detect default branch. Use --base <branch> to specify manually.",
     )?;
     rt.block_on(client.get_default_branch(&repo_id))

--- a/crates/rung-cli/src/forge.rs
+++ b/crates/rung-cli/src/forge.rs
@@ -14,36 +14,49 @@ use rung_forge::{
     MergePullRequest, MergeResult, PullRequest, RepoId, Result as ForgeResult, UpdateComment,
     UpdatePullRequest,
 };
-use rung_github::{Auth, GitHubClient};
+use rung_github::{Auth as GitHubAuth, GitHubClient};
+use rung_gitlab::{Auth as GitLabAuth, GitLabClient};
 
 /// A forge client, statically dispatched by backend kind.
 pub enum Forge {
     /// GitHub backend.
     GitHub(GitHubClient),
+    /// GitLab backend.
+    GitLab(GitLabClient),
 }
 
 impl Forge {
     /// Build a forge client for a git remote, dispatching on the detected forge.
     ///
+    /// Credentials are resolved per backend from its own environment/CLI
+    /// (`GITHUB_TOKEN`/`gh` for GitHub, `GITLAB_TOKEN`/`glab` for GitLab), so
+    /// call sites stay backend-agnostic.
+    ///
     /// # Errors
     /// Returns an error if the remote is not a recognized forge, or if
     /// authentication for the detected forge fails.
-    pub fn for_remote(remote_url: &str, auth: &Auth) -> Result<Self> {
+    pub fn for_remote(remote_url: &str) -> Result<Self> {
+        // `test_token` is `None` in production (each backend resolves its own
+        // credentials); tests inject a token so dispatch is exercised without
+        // shelling out to `gh`/`glab`.
+        Self::for_remote_impl(remote_url, None)
+    }
+
+    fn for_remote_impl(remote_url: &str, test_token: Option<&str>) -> Result<Self> {
         match ForgeKind::detect(remote_url) {
             Some(kind @ ForgeKind::GitHub) => {
-                let client = GitHubClient::new(auth).with_context(|| {
-                    format!(
-                        "Failed to authenticate with {} - {}",
-                        kind.display_name(),
-                        kind.auth_hint()
-                    )
-                })?;
+                let auth = test_token.map_or_else(GitHubAuth::auto, |t| {
+                    GitHubAuth::Token(rung_github::SecretString::from(t))
+                });
+                let client = GitHubClient::new(&auth).with_context(|| auth_context(kind))?;
                 Ok(Self::GitHub(client))
             }
-            // GitLab remotes are recognized by `ForgeKind::detect`, but the
-            // GitLab backend is not yet wired into the CLI (#171).
-            Some(ForgeKind::GitLab) => {
-                Err(anyhow!("GitLab support is not yet available in the CLI"))
+            Some(kind @ ForgeKind::GitLab) => {
+                let auth = test_token.map_or_else(GitLabAuth::auto, |t| {
+                    GitLabAuth::Token(rung_gitlab::SecretString::from(t))
+                });
+                let client = GitLabClient::new(&auth).with_context(|| auth_context(kind))?;
+                Ok(Self::GitLab(client))
             }
             None => Err(anyhow!(
                 "unsupported forge: remote is not a recognized forge repository (supported: {})",
@@ -53,6 +66,15 @@ impl Forge {
     }
 }
 
+/// Authentication-failure context for a detected forge.
+fn auth_context(kind: ForgeKind) -> String {
+    format!(
+        "Failed to authenticate with {} - {}",
+        kind.display_name(),
+        kind.auth_hint()
+    )
+}
+
 // `GitHubClient` has inherent `(owner, repo, …)` methods that shadow the
 // trait's `(&RepoId, …)` methods under normal method-call resolution, so each
 // arm dispatches through `ForgeApi` explicitly to reach the trait impl.
@@ -60,6 +82,7 @@ impl ForgeApi for Forge {
     async fn get_pr(&self, repo: &RepoId, number: u64) -> ForgeResult<PullRequest> {
         match self {
             Self::GitHub(c) => ForgeApi::get_pr(c, repo, number).await,
+            Self::GitLab(c) => ForgeApi::get_pr(c, repo, number).await,
         }
     }
 
@@ -70,6 +93,7 @@ impl ForgeApi for Forge {
     ) -> ForgeResult<HashMap<u64, PullRequest>> {
         match self {
             Self::GitHub(c) => ForgeApi::get_prs_batch(c, repo, numbers).await,
+            Self::GitLab(c) => ForgeApi::get_prs_batch(c, repo, numbers).await,
         }
     }
 
@@ -80,12 +104,14 @@ impl ForgeApi for Forge {
     ) -> ForgeResult<Option<PullRequest>> {
         match self {
             Self::GitHub(c) => ForgeApi::find_pr_for_branch(c, repo, branch).await,
+            Self::GitLab(c) => ForgeApi::find_pr_for_branch(c, repo, branch).await,
         }
     }
 
     async fn create_pr(&self, repo: &RepoId, pr: CreatePullRequest) -> ForgeResult<PullRequest> {
         match self {
             Self::GitHub(c) => ForgeApi::create_pr(c, repo, pr).await,
+            Self::GitLab(c) => ForgeApi::create_pr(c, repo, pr).await,
         }
     }
 
@@ -97,12 +123,14 @@ impl ForgeApi for Forge {
     ) -> ForgeResult<PullRequest> {
         match self {
             Self::GitHub(c) => ForgeApi::update_pr(c, repo, number, update).await,
+            Self::GitLab(c) => ForgeApi::update_pr(c, repo, number, update).await,
         }
     }
 
     async fn get_check_runs(&self, repo: &RepoId, commit_sha: &str) -> ForgeResult<Vec<CheckRun>> {
         match self {
             Self::GitHub(c) => ForgeApi::get_check_runs(c, repo, commit_sha).await,
+            Self::GitLab(c) => ForgeApi::get_check_runs(c, repo, commit_sha).await,
         }
     }
 
@@ -114,18 +142,21 @@ impl ForgeApi for Forge {
     ) -> ForgeResult<MergeResult> {
         match self {
             Self::GitHub(c) => ForgeApi::merge_pr(c, repo, number, merge).await,
+            Self::GitLab(c) => ForgeApi::merge_pr(c, repo, number, merge).await,
         }
     }
 
     async fn delete_ref(&self, repo: &RepoId, ref_name: &str) -> ForgeResult<()> {
         match self {
             Self::GitHub(c) => ForgeApi::delete_ref(c, repo, ref_name).await,
+            Self::GitLab(c) => ForgeApi::delete_ref(c, repo, ref_name).await,
         }
     }
 
     async fn get_default_branch(&self, repo: &RepoId) -> ForgeResult<String> {
         match self {
             Self::GitHub(c) => ForgeApi::get_default_branch(c, repo).await,
+            Self::GitLab(c) => ForgeApi::get_default_branch(c, repo).await,
         }
     }
 
@@ -136,6 +167,7 @@ impl ForgeApi for Forge {
     ) -> ForgeResult<Vec<IssueComment>> {
         match self {
             Self::GitHub(c) => ForgeApi::list_pr_comments(c, repo, pr_number).await,
+            Self::GitLab(c) => ForgeApi::list_pr_comments(c, repo, pr_number).await,
         }
     }
 
@@ -147,6 +179,7 @@ impl ForgeApi for Forge {
     ) -> ForgeResult<IssueComment> {
         match self {
             Self::GitHub(c) => ForgeApi::create_pr_comment(c, repo, pr_number, comment).await,
+            Self::GitLab(c) => ForgeApi::create_pr_comment(c, repo, pr_number, comment).await,
         }
     }
 
@@ -161,6 +194,9 @@ impl ForgeApi for Forge {
             Self::GitHub(c) => {
                 ForgeApi::update_pr_comment(c, repo, pr_number, comment_id, comment).await
             }
+            Self::GitLab(c) => {
+                ForgeApi::update_pr_comment(c, repo, pr_number, comment_id, comment).await
+            }
         }
     }
 }
@@ -169,30 +205,50 @@ impl ForgeApi for Forge {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
-    use rung_github::SecretString;
 
-    fn test_auth() -> Auth {
-        Auth::Token(SecretString::from("test_token"))
+    /// Resolve a forge with an injected token so dispatch is exercised without
+    /// shelling out to `gh`/`glab`.
+    fn for_remote(remote_url: &str) -> Result<Forge> {
+        Forge::for_remote_impl(remote_url, Some("test_token"))
     }
 
     #[test]
     fn test_for_remote_github_https() {
-        let forge = Forge::for_remote("https://github.com/octocat/hello-world.git", &test_auth())
+        let forge = for_remote("https://github.com/octocat/hello-world.git")
             .expect("github remote should resolve");
         assert!(matches!(forge, Forge::GitHub(_)));
     }
 
     #[test]
     fn test_for_remote_github_ssh() {
-        let forge = Forge::for_remote("git@github.com:octocat/hello-world.git", &test_auth())
+        let forge = for_remote("git@github.com:octocat/hello-world.git")
             .expect("github ssh remote should resolve");
         assert!(matches!(forge, Forge::GitHub(_)));
     }
 
     #[test]
-    fn test_for_remote_unsupported_forge_errors() {
-        // A recognizable-but-unsupported forge must not silently fall back to GitHub.
-        assert!(Forge::for_remote("https://gitlab.com/owner/repo.git", &test_auth()).is_err());
-        assert!(Forge::for_remote("not a url", &test_auth()).is_err());
+    fn test_for_remote_gitlab_https() {
+        let forge =
+            for_remote("https://gitlab.com/owner/repo.git").expect("gitlab remote should resolve");
+        assert!(matches!(forge, Forge::GitLab(_)));
+    }
+
+    #[test]
+    fn test_for_remote_gitlab_ssh() {
+        let remote = "git@gitlab.com:group/subgroup/project.git";
+        let forge = for_remote(remote).expect("gitlab ssh remote should resolve");
+        assert!(matches!(forge, Forge::GitLab(_)));
+
+        // The full nested namespace must survive as the repo identity; the
+        // GitLab client URL-encodes this whole path when addressing the project.
+        let info = rung_forge::parse_remote(remote).expect("gitlab ssh remote should parse");
+        assert_eq!(info.repo.path(), "group/subgroup/project");
+    }
+
+    #[test]
+    fn test_for_remote_unrecognized_forge_errors() {
+        // An unrecognized remote must not silently fall back to a known forge.
+        assert!(for_remote("https://example.com/owner/repo.git").is_err());
+        assert!(for_remote("not a url").is_err());
     }
 }

--- a/crates/rung-cli/src/services/absorb.rs
+++ b/crates/rung-cli/src/services/absorb.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use rung_core::StateStore;
 use rung_core::absorb::{self, AbsorbPlan, AbsorbResult};
 use rung_git::AbsorbOps;
-use rung_github::{Auth, ForgeApi};
+use rung_github::ForgeApi;
 
 use crate::forge::Forge;
 
@@ -40,7 +40,7 @@ impl<'a, G: AbsorbOps> AbsorbService<'a, G> {
             kind,
         } = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
 
-        let client = Forge::for_remote(&origin_url, &Auth::auto()).with_context(|| {
+        let client = Forge::for_remote(&origin_url).with_context(|| {
             format!(
                 "{} auth required to detect default branch. \
                  Use --base <branch> to specify manually.",

--- a/crates/rung-cli/src/services/doctor.rs
+++ b/crates/rung-cli/src/services/doctor.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 
 use anyhow::{Context, Result};
 use rung_core::Stack;
-use rung_github::{Auth, ForgeApi, PullRequestState};
+use rung_github::{ForgeApi, PullRequestState};
 
 use crate::forge::Forge;
 use serde::Serialize;
@@ -351,19 +351,8 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
             return result;
         };
 
-        // GitLab remotes parse successfully but the backend is not yet wired
-        // into the CLI (#171); report that rather than a misleading auth error.
-        if kind == rung_forge::ForgeKind::GitLab {
-            result.issues.push(Issue::warning(format!(
-                "{} remotes are not yet supported by the CLI",
-                kind.display_name()
-            )));
-            return result;
-        }
-
         // Authenticate with the detected forge.
-        let auth = Auth::auto();
-        let Ok(client) = Forge::for_remote(&origin_url, &auth) else {
+        let Ok(client) = Forge::for_remote(&origin_url) else {
             result.issues.push(
                 Issue::error(format!("{} authentication failed", kind.display_name()))
                     .with_suggestion(kind.auth_hint()),

--- a/crates/rung-forge/src/remote.rs
+++ b/crates/rung-forge/src/remote.rs
@@ -118,15 +118,18 @@ fn parse_host(url: &str, kind: ForgeKind, host: &str) -> Result<RemoteInfo> {
     if let Some(path) = path {
         let path = path.trim_end_matches('/');
         let path = path.strip_suffix(".git").unwrap_or(path);
-        // Require exactly `owner/repo` — reject extra path segments so a
-        // malformed remote fails here rather than later as a bad API repo name.
-        // The guard proves `path` is exactly two non-empty segments, so it is
-        // already the canonical `owner/repo` slug; use it as-is.
-        let mut parts = path.split('/');
-        if let (Some(owner), Some(repo), None) = (parts.next(), parts.next(), parts.next())
-            && !owner.is_empty()
-            && !repo.is_empty()
-        {
+        // GitHub repositories are always `owner/repo`, so reject extra segments
+        // as malformed. GitLab projects live under nested namespaces
+        // (`group/subgroup/project`), so accept two or more segments there. In
+        // both cases every segment must be non-empty; the validated path is the
+        // canonical slug, used as-is.
+        let segments: Vec<&str> = path.split('/').collect();
+        let segments_ok = segments.iter().all(|s| !s.is_empty())
+            && match kind {
+                ForgeKind::GitHub => segments.len() == 2,
+                ForgeKind::GitLab => segments.len() >= 2,
+            };
+        if segments_ok {
             return Ok(RemoteInfo {
                 kind,
                 repo: RepoId::new(path),
@@ -245,6 +248,31 @@ mod tests {
         let info = parse_remote("git@gitlab.com:octocat/hello-world.git").unwrap();
         assert_eq!(info.kind, ForgeKind::GitLab);
         assert_eq!(info.repo.path(), "octocat/hello-world");
+    }
+
+    #[test]
+    fn test_parse_gitlab_nested_namespace_https() {
+        // GitLab projects can live under nested namespaces; the whole path is
+        // retained as the repo identity (the client URL-encodes it).
+        let info = parse_remote("https://gitlab.com/group/subgroup/project.git").unwrap();
+        assert_eq!(info.kind, ForgeKind::GitLab);
+        assert_eq!(info.repo.path(), "group/subgroup/project");
+    }
+
+    #[test]
+    fn test_parse_gitlab_nested_namespace_ssh() {
+        let info = parse_remote("git@gitlab.com:group/subgroup/project.git").unwrap();
+        assert_eq!(info.kind, ForgeKind::GitLab);
+        assert_eq!(info.repo.path(), "group/subgroup/project");
+    }
+
+    #[test]
+    fn test_parse_github_rejects_nested_namespace() {
+        // GitHub has no nested namespaces; extra segments stay an error.
+        assert!(matches!(
+            parse_remote("git@github.com:group/subgroup/project.git").unwrap_err(),
+            ForgeError::InvalidRemoteUrl(_)
+        ));
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,12 +135,11 @@ rung-cli
     ├── rung-forge              # ForgeApi trait, RepoId, ForgeKind detection
     ├── rung-github             # GitHub backend
     │   └── rung-forge
+    ├── rung-gitlab             # GitLab backend (implements rung-forge)
+    │   └── rung-forge
     └── clap (CLI parsing)
          tokio (async runtime)
          serde_json (output)
-
-rung-gitlab                     # GitLab backend (implements rung-forge); CLI wiring pending (#171)
-    └── rung-forge
 ```
 
 ---
@@ -825,7 +824,7 @@ pub enum RungError {
 
 ### Phase 2 Features (Not in MVP)
 
-1. **GitLab Support**: The `rung-forge` contract and `rung-gitlab` backend (auth + client scaffold) exist; remaining work is the `ForgeApi` implementation (#170) and CLI wiring (#171)
+1. **GitLab Support**: The `rung-forge` contract, the `rung-gitlab` backend (full `ForgeApi` over GitLab REST v4), and CLI dispatch via the `Forge` factory are all in place; remaining work is self-hosted instance host configuration (#172)
 2. **Multi-Root Stacks**: Allow branch to depend on multiple parents
 3. **Auto-Sync**: Watch for upstream changes, notify user
 4. **Team Collaboration**: Shared stacks across team members


### PR DESCRIPTION
## Summary

Wires the GitLab backend into the CLI so GitLab remotes work end-to-end. Fixes #171.

Builds on #180 (the `ForgeApi` implementation for `GitLabClient`).

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — N/A, no new CLI commands; GitLab now works on the existing commands
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Feature
- **Current behavior**: `Forge::for_remote` only dispatched GitHub; a GitLab remote returned "GitLab support is not yet available in the CLI".
- **New behavior**:
  - Added a `Forge::GitLab(GitLabClient)` variant with a `GitLab` arm on every `ForgeApi` method, dispatched from `Forge::for_remote` when `ForgeKind::detect` resolves a GitLab remote.
  - `for_remote` no longer takes a GitHub-typed `Auth`. Each backend now resolves its own credentials internally (`GITHUB_TOKEN`/`gh` for GitHub, `GITLAB_TOKEN`/`glab` for GitLab), so call sites stay backend-agnostic. Removed the now-redundant `&Auth::auto()` argument and unused `Auth` imports from the six call sites (`commands/{merge,sync,status,submit}`, `services/{doctor,absorb}`).
  - A private `for_remote_impl(url, test_token)` seam lets unit tests exercise real dispatch without shelling out to `gh`/`glab`.
  - Removed the stale "GitLab not yet supported by the CLI" warning branch in `sync`.
  - Added tests for GitLab HTTPS/SSH (incl. nested namespace) dispatch; updated the unsupported-forge test to use a genuinely unrecognized host.
  - Updated `docs/architecture.md` crate diagram and Phase 2 notes.
- **Breaking changes?**: No. (`Forge::for_remote` dropped its `auth` parameter, but it is an internal CLI type.)

## Other Information

Self-hosted GitLab instance host configuration remains tracked in #172.
