### PR TITLE
feat(gitlab): support self-hosted GitLab instances (#172)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
       # Lint on the MSRV toolchain (not floating stable) so clippy/rustfmt
       # behavior is tied to the compiler version the project commits to
       # support. This keeps lint results deterministic: a newer stable clippy
-      # cannot introduce lints that break CI without an MSRV bump.
+      # cannot introduce lints that break CI without an MSRV bump. The `@1.88`
+      # ref is the action's version-pinned branch, avoiding the moving `@master`.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@1.88
         with:
-          toolchain: "1.88"
           components: rustfmt, clippy
 
       - name: Cache cargo registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Lint on the MSRV toolchain (not floating stable) so clippy/rustfmt
+      # behavior is tied to the compiler version the project commits to
+      # support. This keeps lint results deterministic: a newer stable clippy
+      # cannot introduce lints that break CI without an MSRV bump.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: "1.88"
           components: rustfmt, clippy
 
       - name: Cache cargo registry

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,7 +88,7 @@ _Long-term vision — ideas we're excited about but haven't fully designed_
 
 ### Ecosystem Integration
 
-- [ ] **GitLab support** — Extend forge support beyond GitHub
+- [x] **GitLab support** ([#145](https://github.com/auswm85/rung/issues/145)) — Full merge request, CI status, and comment support over GitLab REST v4, including self-hosted instances via `gitlab.api_url`
 - [ ] **Bitbucket support** — Enterprise Git hosting integration
 - [x] **Editor extensions** — VS Code extension for stack visualization (in `vscode-extension/`)
 

--- a/crates/rung-cli/src/commands/absorb.rs
+++ b/crates/rung-cli/src/commands/absorb.rs
@@ -40,7 +40,7 @@ pub fn run(dry_run: bool, base: Option<&str>) -> Result<()> {
         b.to_string()
     } else {
         let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(service.detect_base_branch())?
+        rt.block_on(service.detect_base_branch(&state.load_config()?))?
     };
 
     // Create absorb plan

--- a/crates/rung-cli/src/commands/merge.rs
+++ b/crates/rung-cli/src/commands/merge.rs
@@ -67,7 +67,8 @@ fn setup_merge_context(repo: &Repository, state: &State) -> Result<(MergeContext
     let stack_parent_branch = branch.parent.as_ref().map(ToString::to_string);
 
     let origin_url = repo.origin_url()?;
-    let rung_forge::RemoteInfo { repo: repo_id, .. } = rung_forge::parse_remote(&origin_url)?;
+    let rung_forge::RemoteInfo { repo: repo_id, .. } =
+        crate::forge::parse_remote(&origin_url, &state.load_config()?)?;
 
     let descendants =
         MergeService::<Repository, Forge>::collect_descendants(&stack, &current_branch);
@@ -191,7 +192,7 @@ async fn execute_merge(
     json: bool,
 ) -> Result<(String, usize)> {
     let origin_url = repo.origin_url()?;
-    let client = Forge::for_remote(&origin_url)?;
+    let client = Forge::for_remote(&origin_url, &state.load_config()?)?;
     let service = MergeService::new(repo, &client, ctx.repo_id.clone());
 
     // Step 1: Validate PR is mergeable

--- a/crates/rung-cli/src/commands/status.rs
+++ b/crates/rung-cli/src/commands/status.rs
@@ -58,7 +58,9 @@ pub fn run(json: bool, fetch: bool) -> Result<()> {
 
     // Fetch PR statuses if requested (best-effort - don't fail status command on GitHub errors)
     let mut pr_cache = HashMap::new();
-    if fetch && let Err(e) = fetch_pr_statuses(&repo, &stack, &mut pr_cache, json) {
+    if fetch
+        && let Err(e) = fetch_pr_statuses(&repo, &stack, &state.load_config()?, &mut pr_cache, json)
+    {
         if json {
             eprintln!("Warning: Could not fetch PR statuses: {e}");
         } else {
@@ -111,6 +113,7 @@ pub fn run(json: bool, fetch: bool) -> Result<()> {
 fn fetch_pr_statuses(
     repo: &Repository,
     stack: &rung_core::Stack,
+    config: &rung_core::Config,
     pr_cache: &mut HashMap<u64, rung_github::PullRequest>,
     json: bool,
 ) -> Result<()> {
@@ -122,9 +125,10 @@ fn fetch_pr_statuses(
 
     let origin_url = repo.origin_url().context("No origin remote configured")?;
     let rung_forge::RemoteInfo { repo: repo_id, .. } =
-        rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
+        crate::forge::parse_remote(&origin_url, config)
+            .context("Could not parse forge remote URL")?;
 
-    let client = Forge::for_remote(&origin_url)?;
+    let client = Forge::for_remote(&origin_url, config)?;
     let rt = tokio::runtime::Runtime::new()?;
 
     if !json {

--- a/crates/rung-cli/src/commands/submit.rs
+++ b/crates/rung-cli/src/commands/submit.rs
@@ -105,10 +105,11 @@ pub fn run(
             .context("Failed to load default branch from config")?,
     };
 
-    let repo_id = get_remote_info(&repo)?;
+    let forge_config = state.load_config()?;
+    let repo_id = get_remote_info(&repo, &forge_config)?;
 
     let origin_url = repo.origin_url().context("No origin remote configured")?;
-    let client = Forge::for_remote(&origin_url)?;
+    let client = Forge::for_remote(&origin_url, &forge_config)?;
     let rt = tokio::runtime::Runtime::new()?;
 
     let service = SubmitService::new(&repo, &client, repo_id.clone());
@@ -326,9 +327,10 @@ fn prompt_and_handle_uncommitted(repo: &Repository) -> Result<()> {
 }
 
 /// Get the forge-neutral repository identifier from the origin remote.
-fn get_remote_info(repo: &Repository) -> Result<rung_forge::RepoId> {
+fn get_remote_info(repo: &Repository, config: &rung_core::Config) -> Result<rung_forge::RepoId> {
     let origin_url = repo.origin_url().context("No origin remote configured")?;
-    let info = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
+    let info = crate::forge::parse_remote(&origin_url, config)
+        .context("Could not parse forge remote URL")?;
     Ok(info.repo)
 }
 

--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -8,10 +8,10 @@
 //! 5. Pushes all synced branches
 
 use anyhow::{Context, Result, bail};
-use rung_core::State;
 use rung_core::sync::{
     self, ReconcileResult, SyncConflictPrediction, SyncResult, predict_sync_conflicts,
 };
+use rung_core::{Config, State};
 use rung_git::Repository;
 use rung_github::{ForgeApi, RepoId};
 use serde::Serialize;
@@ -138,18 +138,22 @@ pub fn run(
 
     repo.require_clean()?;
 
+    // Load config once; it carries any self-hosted GitLab host used for forge
+    // detection and client construction below.
+    let config = state.load_config()?;
+
     // Try to get the forge remote info (optional - needed for PR operations)
     let origin_url = repo.origin_url().ok();
     let forge_info = origin_url
         .as_deref()
-        .and_then(|url| rung_forge::parse_remote(url).ok())
+        .and_then(|url| crate::forge::parse_remote(url, &config).ok())
         .map(|info| info.repo);
 
     // Create runtime once for all async operations
     let rt = tokio::runtime::Runtime::new()?;
 
     // Determine base branch
-    let base_branch = determine_base_branch(base, origin_url.as_deref(), &rt)?;
+    let base_branch = determine_base_branch(base, origin_url.as_deref(), &config, &rt)?;
 
     // Fetch base branch (skip for --check to keep it side-effect free)
     if !check {
@@ -166,7 +170,7 @@ pub fn run(
     // Create the forge client (if available)
     let mut forge_auth_unavailable = false;
     let client = match (forge_info.as_ref(), origin_url.as_deref()) {
-        (Some(_), Some(url)) => Forge::for_remote(url)
+        (Some(_), Some(url)) => Forge::for_remote(url, &config)
             .map_err(|_| {
                 forge_auth_unavailable = true;
                 if !json {
@@ -201,11 +205,10 @@ pub fn run(
 ///
 /// Used to annotate `--json` output: `true` only when there is a recognized
 /// forge remote but a client for it cannot be constructed (auth failure).
-fn forge_auth_unavailable(repo: &Repository) -> bool {
-    repo.origin_url()
-        .ok()
-        .as_deref()
-        .is_some_and(|url| rung_forge::parse_remote(url).is_ok() && Forge::for_remote(url).is_err())
+fn forge_auth_unavailable(repo: &Repository, config: &Config) -> bool {
+    repo.origin_url().ok().as_deref().is_some_and(|url| {
+        crate::forge::parse_remote(url, config).is_ok() && Forge::for_remote(url, config).is_err()
+    })
 }
 
 /// Handle --abort flag.
@@ -221,7 +224,7 @@ fn handle_abort(repo: &Repository, state: &State, json: bool) -> Result<()> {
             backup_id: None,
             conflict_branch: None,
             conflict_files: vec![],
-            forge_auth_unavailable: forge_auth_unavailable(repo),
+            forge_auth_unavailable: forge_auth_unavailable(repo, &state.load_config()?),
         });
     }
     output::success("Sync aborted - branches restored from backup");
@@ -245,13 +248,18 @@ fn handle_continue(repo: &Repository, state: &State, json: bool, no_push: bool) 
         push_stack_branches(repo, state, json)?;
     }
 
-    handle_sync_result(result, json, forge_auth_unavailable(repo))
+    handle_sync_result(
+        result,
+        json,
+        forge_auth_unavailable(repo, &state.load_config()?),
+    )
 }
 
 /// Determine base branch from --base flag or the forge API.
 fn determine_base_branch(
     base: Option<&str>,
     origin_url: Option<&str>,
+    config: &Config,
     rt: &tokio::runtime::Runtime,
 ) -> Result<String> {
     if let Some(b) = base {
@@ -264,12 +272,12 @@ fn determine_base_branch(
         )
     })?;
     let rung_forge::RemoteInfo { repo: repo_id, .. } =
-        rung_forge::parse_remote(url).map_err(|_| {
+        crate::forge::parse_remote(url, config).map_err(|_| {
             anyhow::anyhow!(
                 "Could not detect forge remote (unsupported URL). Use --base <branch> to specify manually."
             )
         })?;
-    let client = Forge::for_remote(url).context(
+    let client = Forge::for_remote(url, config).context(
         "Forge auth required to detect default branch. Use --base <branch> to specify manually.",
     )?;
     rt.block_on(client.get_default_branch(&repo_id))

--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -224,7 +224,13 @@ fn handle_abort(repo: &Repository, state: &State, json: bool) -> Result<()> {
             backup_id: None,
             conflict_branch: None,
             conflict_files: vec![],
-            forge_auth_unavailable: forge_auth_unavailable(repo, &state.load_config()?),
+            // Best-effort: aborting must not depend on config parsing, so a
+            // malformed config just yields the default (no self-hosted host)
+            // rather than blocking the abort.
+            forge_auth_unavailable: forge_auth_unavailable(
+                repo,
+                &state.load_config().unwrap_or_default(),
+            ),
         });
     }
     output::success("Sync aborted - branches restored from backup");
@@ -248,10 +254,12 @@ fn handle_continue(repo: &Repository, state: &State, json: bool, no_push: bool) 
         push_stack_branches(repo, state, json)?;
     }
 
+    // Best-effort config load: continuing a sync must not fail on a malformed
+    // config (the value only annotates JSON output).
     handle_sync_result(
         result,
         json,
-        forge_auth_unavailable(repo, &state.load_config()?),
+        forge_auth_unavailable(repo, &state.load_config().unwrap_or_default()),
     )
 }
 

--- a/crates/rung-cli/src/forge.rs
+++ b/crates/rung-cli/src/forge.rs
@@ -23,10 +23,12 @@ use rung_gitlab::{Auth as GitLabAuth, GitLabClient};
 ///
 /// A scheme-less value (`gitlab.example.com/api/v4`) is treated as `https` so it
 /// still yields a usable URL for both host detection and API requests, rather
-/// than being silently dropped.
+/// than being silently dropped. A value that already carries a scheme is left
+/// untouched — including a non-HTTP one like `ssh://…`, which then fails host
+/// derivation (rather than being mangled into `https://ssh://…`).
 fn gitlab_api_url(config: &Config) -> Option<String> {
     config.gitlab.api_url.as_deref().map(|url| {
-        if url.starts_with("http://") || url.starts_with("https://") {
+        if url.contains("://") {
             url.to_owned()
         } else {
             format!("https://{url}")
@@ -389,6 +391,16 @@ mod tests {
             .expect("scheme-less api_url should still derive the host");
         assert_eq!(info.kind, ForgeKind::GitLab);
         assert_eq!(info.repo.path(), "group/project");
+    }
+
+    #[test]
+    fn test_non_http_api_url_is_not_coerced() {
+        // A misconfigured non-HTTP scheme must not be mangled into
+        // `https://ssh://…`; it fails host derivation, so a self-hosted remote
+        // is simply not recognized (falls back to the hosted-forge rules).
+        let mut config = Config::default();
+        config.gitlab.api_url = Some("ssh://gitlab.example.com/api/v4".into());
+        assert!(parse_remote("git@gitlab.example.com:group/project.git", &config).is_err());
     }
 
     #[test]

--- a/crates/rung-cli/src/forge.rs
+++ b/crates/rung-cli/src/forge.rs
@@ -18,17 +18,29 @@ use rung_forge::{
 use rung_github::{Auth as GitHubAuth, GitHubClient};
 use rung_gitlab::{Auth as GitLabAuth, GitLabClient};
 
+/// The configured self-hosted GitLab API base URL, normalized to include a
+/// scheme.
+///
+/// A scheme-less value (`gitlab.example.com/api/v4`) is treated as `https` so it
+/// still yields a usable URL for both host detection and API requests, rather
+/// than being silently dropped.
+fn gitlab_api_url(config: &Config) -> Option<String> {
+    config.gitlab.api_url.as_deref().map(|url| {
+        if url.starts_with("http://") || url.starts_with("https://") {
+            url.to_owned()
+        } else {
+            format!("https://{url}")
+        }
+    })
+}
+
 /// Self-hosted GitLab host derived from `gitlab.api_url`, if configured.
 ///
 /// The host cannot be inferred from a self-hosted remote URL alone, so it is
 /// resolved from the configured API base URL and used to extend forge detection
 /// and credential lookup beyond `gitlab.com`.
-fn gitlab_host(config: &Config) -> Option<&str> {
-    config
-        .gitlab
-        .api_url
-        .as_deref()
-        .and_then(rung_forge::host_from_url)
+fn gitlab_host(config: &Config) -> Option<String> {
+    gitlab_api_url(config).and_then(|url| rung_forge::host_from_url(&url).map(str::to_owned))
 }
 
 /// Parse a git remote URL into forge and repository, honoring a configured
@@ -37,7 +49,8 @@ fn gitlab_host(config: &Config) -> Option<&str> {
 /// # Errors
 /// Returns an error if the remote is not a recognized forge repository.
 pub fn parse_remote(remote_url: &str, config: &Config) -> ForgeResult<RemoteInfo> {
-    let hosts: Vec<&str> = gitlab_host(config).into_iter().collect();
+    let host = gitlab_host(config);
+    let hosts: Vec<&str> = host.as_deref().into_iter().collect();
     rung_forge::parse_remote_with_hosts(remote_url, &hosts)
 }
 
@@ -75,7 +88,7 @@ impl Forge {
         test_token: Option<&str>,
     ) -> Result<Self> {
         let gl_host = gitlab_host(config);
-        let hosts: Vec<&str> = gl_host.into_iter().collect();
+        let hosts: Vec<&str> = gl_host.as_deref().into_iter().collect();
         match ForgeKind::detect_with_hosts(remote_url, &hosts) {
             Some(kind @ ForgeKind::GitHub) => {
                 let auth = test_token.map_or_else(GitHubAuth::auto, |t| {
@@ -85,14 +98,22 @@ impl Forge {
                 Ok(Self::GitHub(client))
             }
             Some(kind @ ForgeKind::GitLab) => {
+                // Apply the configured self-hosted host/API URL only when the
+                // remote actually matched it. A gitlab.com remote is recognized
+                // by literal detection (`detect` with no extra hosts), so it
+                // keeps the standard URL and credentials even when a self-hosted
+                // instance is also configured.
+                let self_hosted = gl_host.filter(|_| ForgeKind::detect(remote_url).is_none());
                 let auth = test_token.map_or_else(
-                    || gl_host.map_or_else(GitLabAuth::auto, GitLabAuth::auto_for_host),
+                    || {
+                        self_hosted
+                            .as_deref()
+                            .map_or_else(GitLabAuth::auto, GitLabAuth::auto_for_host)
+                    },
                     |t| GitLabAuth::Token(rung_gitlab::SecretString::from(t)),
                 );
-                let client = config
-                    .gitlab
-                    .api_url
-                    .as_deref()
+                let client = self_hosted
+                    .and_then(|_| gitlab_api_url(config))
                     .map_or_else(
                         || GitLabClient::new(&auth),
                         |base_url| GitLabClient::with_base_url(&auth, base_url),
@@ -346,5 +367,40 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn test_for_remote_self_hosted_scheme_less_api_url() {
+        // A scheme-less api_url must still yield a usable host so self-hosted
+        // detection works rather than falling back to gitlab.com.
+        let forge = for_remote_with_gitlab_api(
+            "https://gitlab.example.com/group/project.git",
+            "gitlab.example.com/api/v4",
+        )
+        .expect("self-hosted remote should resolve with a scheme-less api_url");
+        assert!(matches!(forge, Forge::GitLab(_)));
+    }
+
+    #[test]
+    fn test_parse_remote_scheme_less_api_url() {
+        let mut config = Config::default();
+        config.gitlab.api_url = Some("gitlab.example.com/api/v4".into());
+        let info = parse_remote("git@gitlab.example.com:group/project.git", &config)
+            .expect("scheme-less api_url should still derive the host");
+        assert_eq!(info.kind, ForgeKind::GitLab);
+        assert_eq!(info.repo.path(), "group/project");
+    }
+
+    #[test]
+    fn test_for_remote_gitlab_com_not_misrouted_by_self_hosted_config() {
+        // With a self-hosted instance configured, a gitlab.com remote must still
+        // resolve (via literal detection) and not be treated as unrecognized or
+        // routed to the self-hosted host.
+        let forge = for_remote_with_gitlab_api(
+            "https://gitlab.com/owner/repo.git",
+            "https://gitlab.example.com/api/v4",
+        )
+        .expect("gitlab.com remote should resolve even with self-hosted config");
+        assert!(matches!(forge, Forge::GitLab(_)));
     }
 }

--- a/crates/rung-cli/src/forge.rs
+++ b/crates/rung-cli/src/forge.rs
@@ -9,13 +9,37 @@
 use std::collections::HashMap;
 
 use anyhow::{Context, Result, anyhow};
+use rung_core::Config;
 use rung_forge::{
     CheckRun, CreateComment, CreatePullRequest, ForgeApi, ForgeKind, IssueComment,
-    MergePullRequest, MergeResult, PullRequest, RepoId, Result as ForgeResult, UpdateComment,
-    UpdatePullRequest,
+    MergePullRequest, MergeResult, PullRequest, RemoteInfo, RepoId, Result as ForgeResult,
+    UpdateComment, UpdatePullRequest,
 };
 use rung_github::{Auth as GitHubAuth, GitHubClient};
 use rung_gitlab::{Auth as GitLabAuth, GitLabClient};
+
+/// Self-hosted GitLab host derived from `gitlab.api_url`, if configured.
+///
+/// The host cannot be inferred from a self-hosted remote URL alone, so it is
+/// resolved from the configured API base URL and used to extend forge detection
+/// and credential lookup beyond `gitlab.com`.
+fn gitlab_host(config: &Config) -> Option<&str> {
+    config
+        .gitlab
+        .api_url
+        .as_deref()
+        .and_then(rung_forge::host_from_url)
+}
+
+/// Parse a git remote URL into forge and repository, honoring a configured
+/// self-hosted GitLab host from `config`.
+///
+/// # Errors
+/// Returns an error if the remote is not a recognized forge repository.
+pub fn parse_remote(remote_url: &str, config: &Config) -> ForgeResult<RemoteInfo> {
+    let hosts: Vec<&str> = gitlab_host(config).into_iter().collect();
+    rung_forge::parse_remote_with_hosts(remote_url, &hosts)
+}
 
 /// A forge client, statically dispatched by backend kind.
 pub enum Forge {
@@ -32,18 +56,27 @@ impl Forge {
     /// (`GITHUB_TOKEN`/`gh` for GitHub, `GITLAB_TOKEN`/`glab` for GitLab), so
     /// call sites stay backend-agnostic.
     ///
+    /// `config` supplies the self-hosted GitLab host/API URL (`gitlab.api_url`)
+    /// so remotes on custom hostnames are recognized and addressed correctly.
+    ///
     /// # Errors
     /// Returns an error if the remote is not a recognized forge, or if
     /// authentication for the detected forge fails.
-    pub fn for_remote(remote_url: &str) -> Result<Self> {
+    pub fn for_remote(remote_url: &str, config: &Config) -> Result<Self> {
         // `test_token` is `None` in production (each backend resolves its own
         // credentials); tests inject a token so dispatch is exercised without
         // shelling out to `gh`/`glab`.
-        Self::for_remote_impl(remote_url, None)
+        Self::for_remote_impl(remote_url, config, None)
     }
 
-    fn for_remote_impl(remote_url: &str, test_token: Option<&str>) -> Result<Self> {
-        match ForgeKind::detect(remote_url) {
+    fn for_remote_impl(
+        remote_url: &str,
+        config: &Config,
+        test_token: Option<&str>,
+    ) -> Result<Self> {
+        let gl_host = gitlab_host(config);
+        let hosts: Vec<&str> = gl_host.into_iter().collect();
+        match ForgeKind::detect_with_hosts(remote_url, &hosts) {
             Some(kind @ ForgeKind::GitHub) => {
                 let auth = test_token.map_or_else(GitHubAuth::auto, |t| {
                     GitHubAuth::Token(rung_github::SecretString::from(t))
@@ -52,10 +85,19 @@ impl Forge {
                 Ok(Self::GitHub(client))
             }
             Some(kind @ ForgeKind::GitLab) => {
-                let auth = test_token.map_or_else(GitLabAuth::auto, |t| {
-                    GitLabAuth::Token(rung_gitlab::SecretString::from(t))
-                });
-                let client = GitLabClient::new(&auth).with_context(|| auth_context(kind))?;
+                let auth = test_token.map_or_else(
+                    || gl_host.map_or_else(GitLabAuth::auto, GitLabAuth::auto_for_host),
+                    |t| GitLabAuth::Token(rung_gitlab::SecretString::from(t)),
+                );
+                let client = config
+                    .gitlab
+                    .api_url
+                    .as_deref()
+                    .map_or_else(
+                        || GitLabClient::new(&auth),
+                        |base_url| GitLabClient::with_base_url(&auth, base_url),
+                    )
+                    .with_context(|| auth_context(kind))?;
                 Ok(Self::GitLab(client))
             }
             None => Err(anyhow!(
@@ -209,7 +251,14 @@ mod tests {
     /// Resolve a forge with an injected token so dispatch is exercised without
     /// shelling out to `gh`/`glab`.
     fn for_remote(remote_url: &str) -> Result<Forge> {
-        Forge::for_remote_impl(remote_url, Some("test_token"))
+        Forge::for_remote_impl(remote_url, &Config::default(), Some("test_token"))
+    }
+
+    /// Resolve a forge with a self-hosted GitLab API URL configured.
+    fn for_remote_with_gitlab_api(remote_url: &str, api_url: &str) -> Result<Forge> {
+        let mut config = Config::default();
+        config.gitlab.api_url = Some(api_url.to_string());
+        Forge::for_remote_impl(remote_url, &config, Some("test_token"))
     }
 
     #[test]
@@ -250,5 +299,52 @@ mod tests {
         // An unrecognized remote must not silently fall back to a known forge.
         assert!(for_remote("https://example.com/owner/repo.git").is_err());
         assert!(for_remote("not a url").is_err());
+    }
+
+    #[test]
+    fn test_for_remote_self_hosted_gitlab_resolves() {
+        // A remote on the configured self-hosted host resolves to GitLab.
+        let forge = for_remote_with_gitlab_api(
+            "https://gitlab.example.com/group/project.git",
+            "https://gitlab.example.com/api/v4",
+        )
+        .expect("self-hosted gitlab remote should resolve");
+        assert!(matches!(forge, Forge::GitLab(_)));
+    }
+
+    #[test]
+    fn test_for_remote_self_hosted_gitlab_ssh_resolves() {
+        let forge = for_remote_with_gitlab_api(
+            "git@gitlab.example.com:group/sub/project.git",
+            "https://gitlab.example.com/api/v4",
+        )
+        .expect("self-hosted gitlab ssh remote should resolve");
+        assert!(matches!(forge, Forge::GitLab(_)));
+    }
+
+    #[test]
+    fn test_for_remote_self_hosted_host_unconfigured_errors() {
+        // Without the matching config, the self-hosted host is unrecognized.
+        assert!(for_remote("https://gitlab.example.com/group/project.git").is_err());
+    }
+
+    #[test]
+    fn test_parse_remote_honors_self_hosted_config() {
+        let mut config = Config::default();
+        config.gitlab.api_url = Some("https://gitlab.example.com/api/v4".into());
+
+        let info = parse_remote("git@gitlab.example.com:group/sub/project.git", &config)
+            .expect("self-hosted remote should parse");
+        assert_eq!(info.kind, ForgeKind::GitLab);
+        assert_eq!(info.repo.path(), "group/sub/project");
+
+        // The same remote is unrecognized without the config.
+        assert!(
+            parse_remote(
+                "git@gitlab.example.com:group/sub/project.git",
+                &Config::default()
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/rung-cli/src/services/absorb.rs
+++ b/crates/rung-cli/src/services/absorb.rs
@@ -28,9 +28,11 @@ impl<'a, G: AbsorbOps> AbsorbService<'a, G> {
         Ok(self.repo.has_staged_changes()?)
     }
 
-    /// Detect the base branch by querying GitHub for the default branch.
+    /// Detect the base branch by querying the forge for the default branch.
+    ///
+    /// `config` supplies any self-hosted GitLab host so custom remotes resolve.
     #[allow(clippy::future_not_send)] // Git operations are sync; future doesn't need to be Send
-    pub async fn detect_base_branch(&self) -> Result<String> {
+    pub async fn detect_base_branch(&self, config: &rung_core::Config) -> Result<String> {
         let origin_url = self
             .repo
             .origin_url()
@@ -38,9 +40,10 @@ impl<'a, G: AbsorbOps> AbsorbService<'a, G> {
         let rung_forge::RemoteInfo {
             repo: repo_id,
             kind,
-        } = rung_forge::parse_remote(&origin_url).context("Could not parse forge remote URL")?;
+        } = crate::forge::parse_remote(&origin_url, config)
+            .context("Could not parse forge remote URL")?;
 
-        let client = Forge::for_remote(&origin_url).with_context(|| {
+        let client = Forge::for_remote(&origin_url, config).with_context(|| {
             format!(
                 "{} auth required to detect default branch. \
                  Use --base <branch> to specify manually.",

--- a/crates/rung-cli/src/services/doctor.rs
+++ b/crates/rung-cli/src/services/doctor.rs
@@ -339,9 +339,19 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
             return result;
         };
 
-        // Best-effort: a missing/unreadable config just means no self-hosted
-        // GitLab host, so fall back to defaults rather than failing the check.
-        let config = self.state.load_config().unwrap_or_default();
+        // A missing config is fine (`load_config` returns defaults), but a
+        // malformed/unreadable one is a real problem the doctor should report
+        // rather than silently mask by defaulting.
+        let config = match self.state.load_config() {
+            Ok(config) => config,
+            Err(e) => {
+                result.issues.push(
+                    Issue::error(format!("Could not read rung config: {e}"))
+                        .with_suggestion("Check .git/rung/config.toml for syntax errors"),
+                );
+                return result;
+            }
+        };
 
         let Ok(rung_forge::RemoteInfo {
             repo: repo_id,

--- a/crates/rung-cli/src/services/doctor.rs
+++ b/crates/rung-cli/src/services/doctor.rs
@@ -339,10 +339,14 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
             return result;
         };
 
+        // Best-effort: a missing/unreadable config just means no self-hosted
+        // GitLab host, so fall back to defaults rather than failing the check.
+        let config = self.state.load_config().unwrap_or_default();
+
         let Ok(rung_forge::RemoteInfo {
             repo: repo_id,
             kind,
-        }) = rung_forge::parse_remote(&origin_url)
+        }) = crate::forge::parse_remote(&origin_url, &config)
         else {
             result.issues.push(Issue::warning(format!(
                 "Origin is not a recognized repository (supported: {})",
@@ -352,7 +356,7 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
         };
 
         // Authenticate with the detected forge.
-        let Ok(client) = Forge::for_remote(&origin_url) else {
+        let Ok(client) = Forge::for_remote(&origin_url, &config) else {
             result.issues.push(
                 Issue::error(format!("{} authentication failed", kind.display_name()))
                     .with_suggestion(kind.auth_hint()),

--- a/crates/rung-core/src/config.rs
+++ b/crates/rung-core/src/config.rs
@@ -17,6 +17,10 @@ pub struct Config {
     /// GitHub-specific settings.
     #[serde(default)]
     pub github: GitHubConfig,
+
+    /// GitLab-specific settings.
+    #[serde(default)]
+    pub gitlab: GitLabConfig,
 }
 
 impl Config {
@@ -95,6 +99,19 @@ pub struct GitHubConfig {
     pub api_url: Option<String>,
 }
 
+/// GitLab-specific settings.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GitLabConfig {
+    /// Custom API base URL for self-hosted GitLab instances, e.g.
+    /// `https://gitlab.example.com/api/v4`.
+    ///
+    /// The instance host is derived from this URL, which lets rung recognize
+    /// self-hosted remotes (`git@gitlab.example.com:...`) that cannot be
+    /// inferred from the URL alone.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_url: Option<String>,
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -124,6 +141,9 @@ mod tests {
             github: GitHubConfig {
                 api_url: Some("https://github.example.com/api/v3".into()),
             },
+            gitlab: GitLabConfig {
+                api_url: Some("https://gitlab.example.com/api/v4".into()),
+            },
         };
 
         config.save(&path).unwrap();
@@ -136,6 +156,10 @@ mod tests {
         assert_eq!(
             loaded.github.api_url,
             Some("https://github.example.com/api/v3".into())
+        );
+        assert_eq!(
+            loaded.gitlab.api_url,
+            Some("https://gitlab.example.com/api/v4".into())
         );
     }
 

--- a/crates/rung-forge/src/lib.rs
+++ b/crates/rung-forge/src/lib.rs
@@ -15,7 +15,7 @@ mod traits;
 mod types;
 
 pub use error::{ForgeError, Result};
-pub use remote::{ForgeKind, RemoteInfo, parse_remote};
+pub use remote::{ForgeKind, RemoteInfo, host_from_url, parse_remote, parse_remote_with_hosts};
 pub use repo_id::RepoId;
 pub use traits::ForgeApi;
 pub use types::{

--- a/crates/rung-forge/src/remote.rs
+++ b/crates/rung-forge/src/remote.rs
@@ -56,24 +56,57 @@ impl ForgeKind {
 
     /// Detect the forge that hosts a git remote URL.
     ///
-    /// Recognizes both HTTPS and SSH forms. Returns `None` if the host is not
-    /// a known forge.
+    /// Recognizes both HTTPS and SSH forms against the hosted forges
+    /// (`github.com`, `gitlab.com`). Returns `None` if the host is not a known
+    /// forge. Use [`ForgeKind::detect_with_hosts`] to also recognize self-hosted
+    /// GitLab instances.
     #[must_use]
     pub fn detect(url: &str) -> Option<Self> {
-        if url.starts_with("git@github.com:")
-            || url.starts_with("https://github.com/")
-            || url.starts_with("http://github.com/")
-        {
+        Self::detect_with_hosts(url, &[])
+    }
+
+    /// Detect the forge, additionally treating each host in `gitlab_hosts` as a
+    /// self-hosted GitLab instance.
+    ///
+    /// Self-hosted GitLab lives on arbitrary hostnames that cannot be inferred
+    /// from the URL alone, so the configured hosts are supplied by the caller
+    /// (from `.git/rung/config.toml`). Recognizes both HTTPS and SSH forms.
+    #[must_use]
+    pub fn detect_with_hosts(url: &str, gitlab_hosts: &[&str]) -> Option<Self> {
+        if url_has_host(url, "github.com") {
             return Some(Self::GitHub);
         }
-        if url.starts_with("git@gitlab.com:")
-            || url.starts_with("https://gitlab.com/")
-            || url.starts_with("http://gitlab.com/")
+        if url_has_host(url, "gitlab.com")
+            || gitlab_hosts.iter().any(|host| url_has_host(url, host))
         {
             return Some(Self::GitLab);
         }
         None
     }
+}
+
+/// Whether a remote URL points at `host`, in either SSH or HTTPS/HTTP form.
+fn url_has_host(url: &str, host: &str) -> bool {
+    url.starts_with(&format!("git@{host}:"))
+        || url.starts_with(&format!("https://{host}/"))
+        || url.starts_with(&format!("http://{host}/"))
+}
+
+/// Extract the host from an HTTP(S) URL, e.g.
+/// `https://gitlab.example.com/api/v4` → `Some("gitlab.example.com")`.
+///
+/// Strips any userinfo (`user:pass@`) and port. Returns `None` for URLs that
+/// are not HTTP(S) or that have an empty host. Used to derive a self-hosted
+/// GitLab host from a configured API base URL.
+#[must_use]
+pub fn host_from_url(url: &str) -> Option<&str> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let authority = rest.split('/').next()?;
+    // Drop any `user:pass@` prefix, then any `:port` suffix.
+    let host = authority.rsplit('@').next()?.split(':').next()?;
+    if host.is_empty() { None } else { Some(host) }
 }
 
 /// A repository identified from a git remote URL.
@@ -97,11 +130,32 @@ pub struct RemoteInfo {
 /// Returns [`ForgeError::InvalidRemoteUrl`] if the URL is not a recognized
 /// forge remote or the owner/repo path cannot be extracted.
 pub fn parse_remote(url: &str) -> Result<RemoteInfo> {
-    match ForgeKind::detect(url) {
-        Some(kind @ ForgeKind::GitHub) => parse_host(url, kind, "github.com"),
-        Some(kind @ ForgeKind::GitLab) => parse_host(url, kind, "gitlab.com"),
-        None => Err(ForgeError::InvalidRemoteUrl(url.to_string())),
+    parse_remote_with_hosts(url, &[])
+}
+
+/// Parse a git remote URL, additionally treating each host in `gitlab_hosts` as
+/// a self-hosted GitLab instance.
+///
+/// Mirrors [`ForgeKind::detect_with_hosts`]: the configured hosts extend GitLab
+/// recognition beyond `gitlab.com` so self-hosted remotes resolve to their
+/// project path.
+///
+/// # Errors
+/// Returns [`ForgeError::InvalidRemoteUrl`] if the URL is not a recognized
+/// forge remote or the owner/repo path cannot be extracted.
+pub fn parse_remote_with_hosts(url: &str, gitlab_hosts: &[&str]) -> Result<RemoteInfo> {
+    if url_has_host(url, "github.com") {
+        return parse_host(url, ForgeKind::GitHub, "github.com");
     }
+    if url_has_host(url, "gitlab.com") {
+        return parse_host(url, ForgeKind::GitLab, "gitlab.com");
+    }
+    for host in gitlab_hosts {
+        if url_has_host(url, host) {
+            return parse_host(url, ForgeKind::GitLab, host);
+        }
+    }
+    Err(ForgeError::InvalidRemoteUrl(url.to_string()))
 }
 
 /// Extract `(owner, repo)` from a `host` remote in either SSH or HTTPS form.
@@ -273,6 +327,67 @@ mod tests {
             parse_remote("git@github.com:group/subgroup/project.git").unwrap_err(),
             ForgeError::InvalidRemoteUrl(_)
         ));
+    }
+
+    #[test]
+    fn test_detect_self_hosted_gitlab_https() {
+        let hosts = ["gitlab.example.com"];
+        assert_eq!(
+            ForgeKind::detect_with_hosts("https://gitlab.example.com/group/project.git", &hosts),
+            Some(ForgeKind::GitLab)
+        );
+        // Without the configured host it is unrecognized.
+        assert_eq!(
+            ForgeKind::detect("https://gitlab.example.com/group/project.git"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_detect_self_hosted_gitlab_ssh() {
+        let hosts = ["gitlab.example.com"];
+        assert_eq!(
+            ForgeKind::detect_with_hosts("git@gitlab.example.com:group/project.git", &hosts),
+            Some(ForgeKind::GitLab)
+        );
+    }
+
+    #[test]
+    fn test_parse_self_hosted_gitlab_nested_namespace() {
+        let hosts = ["gitlab.example.com"];
+        let info = parse_remote_with_hosts("git@gitlab.example.com:group/sub/project.git", &hosts)
+            .unwrap();
+        assert_eq!(info.kind, ForgeKind::GitLab);
+        assert_eq!(info.repo.path(), "group/sub/project");
+    }
+
+    #[test]
+    fn test_parse_self_hosted_host_still_honors_hosted_forges() {
+        // A configured self-hosted host must not shadow github.com/gitlab.com.
+        let hosts = ["gitlab.example.com"];
+        let info = parse_remote_with_hosts("https://github.com/octocat/repo.git", &hosts).unwrap();
+        assert_eq!(info.kind, ForgeKind::GitHub);
+    }
+
+    #[test]
+    fn test_host_from_url() {
+        assert_eq!(
+            host_from_url("https://gitlab.example.com/api/v4"),
+            Some("gitlab.example.com")
+        );
+        assert_eq!(
+            host_from_url("http://gitlab.local:8080/api/v4"),
+            Some("gitlab.local")
+        );
+        assert_eq!(
+            host_from_url("https://user:pass@gitlab.example.com/api/v4"),
+            Some("gitlab.example.com")
+        );
+        assert_eq!(
+            host_from_url("git@gitlab.example.com:group/project.git"),
+            None
+        );
+        assert_eq!(host_from_url("https:///api/v4"), None);
     }
 
     #[test]

--- a/crates/rung-forge/src/remote.rs
+++ b/crates/rung-forge/src/remote.rs
@@ -95,17 +95,27 @@ fn url_has_host(url: &str, host: &str) -> bool {
 /// Extract the host from an HTTP(S) URL, e.g.
 /// `https://gitlab.example.com/api/v4` → `Some("gitlab.example.com")`.
 ///
-/// Strips any userinfo (`user:pass@`) and port. Returns `None` for URLs that
-/// are not HTTP(S) or that have an empty host. Used to derive a self-hosted
-/// GitLab host from a configured API base URL.
+/// Strips any userinfo (`user:pass@`) and port. Bracketed IPv6 literals are
+/// returned with their brackets (`https://[::1]:8080/…` → `Some("[::1]")`).
+/// Returns `None` for URLs that are not HTTP(S) or that have an empty host.
+/// Used to derive a self-hosted GitLab host from a configured API base URL.
 #[must_use]
 pub fn host_from_url(url: &str) -> Option<&str> {
     let rest = url
         .strip_prefix("https://")
         .or_else(|| url.strip_prefix("http://"))?;
     let authority = rest.split('/').next()?;
-    // Drop any `user:pass@` prefix, then any `:port` suffix.
-    let host = authority.rsplit('@').next()?.split(':').next()?;
+    // Drop any `user:pass@` userinfo prefix.
+    let host_port = authority.rsplit('@').next()?;
+    let host = if host_port.starts_with('[') {
+        // IPv6 literal: the host is the bracketed portion; a `:port` may follow
+        // the closing bracket. Keep the brackets so the host round-trips in URLs.
+        let end = host_port.find(']')?;
+        &host_port[..=end]
+    } else {
+        // Otherwise strip any `:port` suffix.
+        host_port.split(':').next()?
+    };
     if host.is_empty() { None } else { Some(host) }
 }
 
@@ -388,6 +398,12 @@ mod tests {
             None
         );
         assert_eq!(host_from_url("https:///api/v4"), None);
+        // IPv6 literals keep their brackets and drop the port.
+        assert_eq!(host_from_url("https://[::1]:8080/api/v4"), Some("[::1]"));
+        assert_eq!(
+            host_from_url("http://[2001:db8::1]/api/v4"),
+            Some("[2001:db8::1]")
+        );
     }
 
     #[test]

--- a/crates/rung-gitlab/src/auth.rs
+++ b/crates/rung-gitlab/src/auth.rs
@@ -16,15 +16,17 @@ use rung_forge::{ForgeError as Error, Result};
 
 /// Default GitLab host the `glab` CLI stores credentials under.
 ///
-/// Self-hosted instances are handled separately (see issue #172); for now the
-/// CLI fallback always targets `gitlab.com`.
+/// Self-hosted instances supply their own host via [`Auth::auto_for_host`].
 const DEFAULT_GLAB_HOST: &str = "gitlab.com";
 
 /// Authentication method for the GitLab API.
 #[derive(Debug, Clone)]
 pub enum Auth {
-    /// Use the token stored by the `glab` CLI.
-    GlabCli,
+    /// Use the token stored by the `glab` CLI for the given host.
+    GlabCli {
+        /// GitLab host to read credentials for (`gitlab.com` or self-hosted).
+        host: String,
+    },
 
     /// Use a token from the named environment variable.
     EnvVar(String),
@@ -34,7 +36,7 @@ pub enum Auth {
 }
 
 impl Auth {
-    /// Create auth from the first available method.
+    /// Create auth from the first available method for `gitlab.com`.
     ///
     /// Tries in order: `GITLAB_TOKEN` env var, then the `glab` CLI.
     ///
@@ -42,9 +44,21 @@ impl Auth {
     /// usable `glab` credential.
     #[must_use]
     pub fn auto() -> Self {
+        Self::auto_for_host(DEFAULT_GLAB_HOST)
+    }
+
+    /// Create auth from the first available method for a specific GitLab host.
+    ///
+    /// Behaves like [`Auth::auto`] but, when falling back to the `glab` CLI,
+    /// reads the credential stored for `host` — supporting self-hosted GitLab
+    /// instances. `GITLAB_TOKEN` still takes precedence and is host-agnostic.
+    #[must_use]
+    pub fn auto_for_host(host: &str) -> Self {
         match std::env::var("GITLAB_TOKEN") {
             Ok(token) if !token.trim().is_empty() => Self::EnvVar("GITLAB_TOKEN".into()),
-            _ => Self::GlabCli,
+            _ => Self::GlabCli {
+                host: host.to_owned(),
+            },
         }
     }
 
@@ -58,7 +72,7 @@ impl Auth {
     /// [`ForgeError::NoToken`]: rung_forge::ForgeError::NoToken
     pub fn resolve(&self) -> Result<SecretString> {
         match self {
-            Self::GlabCli => get_glab_token(),
+            Self::GlabCli { host } => get_glab_token(host),
             Self::EnvVar(var) => {
                 let token = std::env::var(var).map_err(|_| Error::NoToken)?;
                 let token = token.trim();
@@ -86,9 +100,9 @@ impl Default for Auth {
 ///
 /// A missing `glab` binary is treated as "no credential source" ([`Error::NoToken`])
 /// rather than an I/O error, matching the [`Auth::resolve`] contract.
-fn get_glab_token() -> Result<SecretString> {
+fn get_glab_token(host: &str) -> Result<SecretString> {
     let output = Command::new("glab")
-        .args(["config", "get", "token", "--host", DEFAULT_GLAB_HOST])
+        .args(["config", "get", "token", "--host", host])
         .output()
         .map_err(|_| Error::NoToken)?;
 
@@ -130,10 +144,23 @@ mod tests {
     }
 
     #[test]
+    fn test_auto_for_host_uses_host_for_glab() {
+        // With no GITLAB_TOKEN set, auto_for_host falls back to the glab CLI
+        // for the requested host. Guarded so an ambient token does not flake.
+        if std::env::var("GITLAB_TOKEN").is_ok_and(|t| !t.trim().is_empty()) {
+            return;
+        }
+        match Auth::auto_for_host("gitlab.example.com") {
+            Auth::GlabCli { host } => assert_eq!(host, "gitlab.example.com"),
+            other => panic!("expected GlabCli, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_auth_default_is_auto() {
         // Default must never be a bare Token; it picks env var or CLI.
         match Auth::default() {
-            Auth::GlabCli | Auth::EnvVar(_) => {}
+            Auth::GlabCli { .. } | Auth::EnvVar(_) => {}
             Auth::Token(_) => panic!("Default should not return Token"),
         }
     }

--- a/crates/rung-gitlab/src/client.rs
+++ b/crates/rung-gitlab/src/client.rs
@@ -213,7 +213,8 @@ pub struct GitLabClient {
 impl GitLabClient {
     /// Default GitLab API base URL (gitlab.com, REST v4).
     ///
-    /// Self-hosted instances supply their own base URL (see issue #172).
+    /// Self-hosted instances supply their own base URL via
+    /// [`GitLabClient::with_base_url`], configured from `gitlab.api_url`.
     pub const DEFAULT_API_URL: &'static str = "https://gitlab.com/api/v4";
 
     /// Create a new GitLab client targeting gitlab.com.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -259,6 +259,11 @@ auto_sync = false
 [github]
 # Optional: override for GitHub Enterprise
 # api_url = "https://github.example.com/api/v3"
+
+[gitlab]
+# Optional: self-hosted GitLab instance. The host is derived from this URL,
+# which lets rung recognize remotes on that host (e.g. git@gitlab.example.com:...).
+# api_url = "https://gitlab.example.com/api/v4"
 ```
 
 **Sync state** in `.git/rung/sync_state` (temporary, deleted on completion):
@@ -824,7 +829,7 @@ pub enum RungError {
 
 ### Phase 2 Features (Not in MVP)
 
-1. **GitLab Support**: The `rung-forge` contract, the `rung-gitlab` backend (full `ForgeApi` over GitLab REST v4), and CLI dispatch via the `Forge` factory are all in place; remaining work is self-hosted instance host configuration (#172)
+1. **GitLab Support**: The `rung-forge` contract, the `rung-gitlab` backend (full `ForgeApi` over GitLab REST v4), and CLI dispatch via the `Forge` factory are all in place, including self-hosted instance host configuration via `gitlab.api_url`
 2. **Multi-Root Stacks**: Allow branch to depend on multiple parents
 3. **Auto-Sync**: Watch for upstream changes, notify user
 4. **Team Collaboration**: Shared stacks across team members


### PR DESCRIPTION
## Summary

Add support for self-hosted GitLab instances (custom hostnames), which `ForgeKind::detect` cannot infer from a remote URL alone. Configure a self-hosted instance with a single `gitlab.api_url` in `.git/rung/config.toml`; the host is derived from that URL to extend forge detection, client construction, and `glab` credential lookup beyond gitlab.com.

Fixes #172. Completes the GitLab epic (#145).

```toml
[gitlab]
api_url = "https://gitlab.example.com/api/v4"
```

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — n/a, no CLI command changes; updated `docs/architecture.md` and `ROADMAP.md`
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Feature
- **Current behavior**: Only `github.com` and `gitlab.com` remotes are recognized. A self-hosted GitLab remote (e.g. `git@gitlab.example.com:group/project.git`) is rejected as an unsupported forge, and the GitLab client always targets `https://gitlab.com/api/v4`.
- **New behavior**: With `gitlab.api_url` configured, rung derives the instance host and:
  - recognizes remotes on that host (HTTPS and SSH, including nested namespaces) during detection and parsing,
  - builds the `GitLabClient` against the configured API base URL,
  - reads the `glab` CLI credential for that host (`glab config get token --host <host>`); `GITLAB_TOKEN` still takes precedence.

  Hosted `github.com`/`gitlab.com` detection is unchanged and is never shadowed by a configured host.
- **Breaking changes?**: No. The new config section is optional and defaults to gitlab.com behavior.

## Other Information

Implementation notes:
- `rung-forge`: added `ForgeKind::detect_with_hosts`, `parse_remote_with_hosts`, and `host_from_url`; the existing `detect`/`parse_remote` delegate with an empty host list (behavior unchanged).
- `rung-core`: added an optional `GitLabConfig { api_url }`, mirroring `GitHubConfig`.
- `rung-gitlab`: `Auth::GlabCli { host }` now carries the host, with a new `Auth::auto_for_host`.
- `rung-cli`: `Forge::for_remote` and a new `forge::parse_remote` now take `&Config`; threaded through `submit`, `merge`, `status`, `sync`, `doctor`, and `absorb`.

Out of scope: GitHub Enterprise's `github.api_url` remains unwired (it was already dead before this change) — can be a follow-up.

Testing: `cargo build`, `cargo clippy --workspace --all-targets` (pedantic + nursery), and `cargo fmt --check` are clean; `cargo test --workspace` passes (368 tests), including 12 new tests covering self-hosted detection/parsing, host derivation, host-aware auth, and config-driven dispatch.
