### PR TITLE
fix(doctor): forge-aware connectivity output + remove GitHub-only assumptions (#185)

### DIFF
--- a/crates/rung-cli/src/commands/doctor.rs
+++ b/crates/rung-cli/src/commands/doctor.rs
@@ -87,12 +87,12 @@ pub fn run(json: bool) -> Result<()> {
     }
 
     if !json {
-        print_check("Checking GitHub...");
+        print_check(&format!("Checking {}...", service.forge_label()));
     }
     let rt = tokio::runtime::Runtime::new()?;
-    let github_result = rt.block_on(service.check_github());
+    let forge_result = rt.block_on(service.check_forge());
     if !json {
-        print_status(&github_result);
+        print_status(&forge_result);
     }
 
     // Collect all issues using DiagnosticReport
@@ -100,7 +100,7 @@ pub fn run(json: bool) -> Result<()> {
         git_state: git_result,
         stack_integrity: stack_result,
         sync_state: sync_result,
-        github: github_result,
+        forge: forge_result,
     };
     let all_issues = report.all_issues();
 

--- a/crates/rung-cli/src/commands/merge.rs
+++ b/crates/rung-cli/src/commands/merge.rs
@@ -179,7 +179,7 @@ pub fn run(json: bool, method: &str, no_delete: bool) -> Result<()> {
     Ok(())
 }
 
-/// Execute the GitHub merge operation.
+/// Execute the forge merge operation.
 /// Returns (`parent_branch`, `descendants_rebased_count`).
 #[allow(clippy::too_many_arguments, clippy::future_not_send)]
 async fn execute_merge(
@@ -220,7 +220,7 @@ async fn execute_merge(
         output::success(&format!("Merged PR #{}", ctx.pr_number));
     }
 
-    // NOTE: After merge_pr succeeds, the PR is merged on GitHub.
+    // NOTE: After merge_pr succeeds, the PR/MR is merged on the forge.
     // Subsequent failures should NOT abort - we log warnings and continue.
 
     // Step 4: Update stack after merge (non-fatal after merge)

--- a/crates/rung-cli/src/commands/mod.rs
+++ b/crates/rung-cli/src/commands/mod.rs
@@ -113,8 +113,8 @@ pub enum Commands {
 
     /// Sync the stack by rebasing all branches. [alias: sy]
     ///
-    /// Detects merged PRs, updates stack topology, rebases branches,
-    /// updates GitHub PR base branches, and pushes all changes.
+    /// Detects merged PRs/MRs, updates stack topology, rebases branches,
+    /// updates PR/MR base branches on the forge, and pushes all changes.
     #[command(alias = "sy")]
     Sync {
         /// Show what would be done without making changes.
@@ -189,10 +189,10 @@ pub enum Commands {
     #[command(alias = "un")]
     Undo,
 
-    /// Merge the current branch's PR and clean up. [alias: m]
+    /// Merge the current branch's PR/MR and clean up. [alias: m]
     ///
-    /// Merges the PR via GitHub API, deletes the remote branch,
-    /// removes it from the stack, and checks out the parent.
+    /// Merges the PR (GitHub) or MR (GitLab) via the forge API, deletes the
+    /// remote branch, removes it from the stack, and checks out the parent.
     #[command(alias = "m")]
     Merge {
         /// Merge method: squash (default), merge, or rebase.
@@ -254,7 +254,7 @@ pub enum Commands {
 
     /// Diagnose issues with the stack and repository. [alias: doc]
     ///
-    /// Checks stack integrity, git state, sync status, and GitHub connectivity.
+    /// Checks stack integrity, git state, sync status, and forge connectivity.
     #[command(alias = "doc")]
     Doctor,
 

--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -486,7 +486,7 @@ fn run_phase_finalize(
         && (!reconcile_result.reparented.is_empty() || !reconcile_result.repaired.is_empty())
     {
         if !json {
-            output::info("Updating PR base branches on GitHub...");
+            output::info("Updating PR/MR base branches on the forge...");
         }
         rt.block_on(service.update_pr_bases(reconcile_result))?;
         print_pr_updates(reconcile_result, json);

--- a/crates/rung-cli/src/services/doctor.rs
+++ b/crates/rung-cli/src/services/doctor.rs
@@ -87,7 +87,7 @@ pub struct DiagnosticReport {
     pub git_state: CheckResult,
     pub stack_integrity: CheckResult,
     pub sync_state: CheckResult,
-    pub github: CheckResult,
+    pub forge: CheckResult,
 }
 
 #[allow(dead_code)]
@@ -99,7 +99,7 @@ impl DiagnosticReport {
             .iter()
             .chain(self.stack_integrity.issues.iter())
             .chain(self.sync_state.issues.iter())
-            .chain(self.github.issues.iter())
+            .chain(self.forge.issues.iter())
             .collect()
     }
 
@@ -142,12 +142,12 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
     #[allow(dead_code)]
     #[allow(clippy::future_not_send)] // Git operations are sync; future doesn't need to be Send
     pub async fn run_diagnostics(&self) -> Result<DiagnosticReport> {
-        let github_result = self.check_github().await;
+        let forge_result = self.check_forge().await;
         Ok(DiagnosticReport {
             git_state: self.check_git_state(),
             stack_integrity: self.check_stack_integrity(),
             sync_state: self.check_sync_state()?,
-            github: github_result,
+            forge: forge_result,
         })
     }
 
@@ -325,9 +325,24 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
         Ok(result)
     }
 
-    /// Check GitHub connectivity and PR state.
+    /// Best-effort name of the forge hosting `origin`, for progress labels.
+    ///
+    /// Returns `"GitHub"` or `"GitLab"` when the remote is recognized (honoring
+    /// a configured self-hosted GitLab host), or `"forge"` when there is no
+    /// origin or it is not a known forge. Purely cosmetic — the connectivity
+    /// check itself reports the authoritative diagnosis.
+    pub fn forge_label(&self) -> &'static str {
+        let Ok(origin_url) = self.repo.origin_url() else {
+            return "forge";
+        };
+        let config = self.state.load_config().unwrap_or_default();
+        crate::forge::parse_remote(&origin_url, &config)
+            .map_or("forge", |info| info.kind.display_name())
+    }
+
+    /// Check forge connectivity (GitHub or GitLab) and PR/MR state.
     #[allow(clippy::future_not_send)] // Git operations are sync; future doesn't need Send
-    pub async fn check_github(&self) -> CheckResult {
+    pub async fn check_forge(&self) -> CheckResult {
         let mut result = CheckResult::default();
 
         // Resolve the remote first so non-forge remotes are reported before any
@@ -509,7 +524,7 @@ mod tests {
             .issues
             .push(Issue::error("stack issue"));
         report.sync_state.issues.push(Issue::warning("sync issue"));
-        report.github.issues.push(Issue::error("github issue"));
+        report.forge.issues.push(Issue::error("forge issue"));
 
         assert_eq!(report.all_issues().len(), 4);
         assert_eq!(report.error_count(), 2);
@@ -624,6 +639,49 @@ mod tests {
             let result = service.check_git_state();
 
             assert!(result.is_clean());
+        }
+
+        #[test]
+        fn test_forge_label_github() {
+            let git = MockGitOps::new().with_origin_url("https://github.com/o/r.git");
+            let state = MockStateStore::new();
+            let stack = Stack::default();
+
+            let service = DoctorService::new(&git, &state, &stack);
+            assert_eq!(service.forge_label(), "GitHub");
+        }
+
+        #[test]
+        fn test_forge_label_gitlab() {
+            let git = MockGitOps::new().with_origin_url("https://gitlab.com/o/r.git");
+            let state = MockStateStore::new();
+            let stack = Stack::default();
+
+            let service = DoctorService::new(&git, &state, &stack);
+            assert_eq!(service.forge_label(), "GitLab");
+        }
+
+        #[test]
+        fn test_forge_label_self_hosted_gitlab_uses_config() {
+            // A self-hosted host is only recognized via configured api_url.
+            let git = MockGitOps::new().with_origin_url("git@gitlab.example.com:o/r.git");
+            let state = MockStateStore::new();
+            state.config.borrow_mut().gitlab.api_url =
+                Some("https://gitlab.example.com/api/v4".to_string());
+            let stack = Stack::default();
+
+            let service = DoctorService::new(&git, &state, &stack);
+            assert_eq!(service.forge_label(), "GitLab");
+        }
+
+        #[test]
+        fn test_forge_label_unrecognized_falls_back() {
+            let git = MockGitOps::new().with_origin_url("https://bitbucket.org/o/r.git");
+            let state = MockStateStore::new();
+            let stack = Stack::default();
+
+            let service = DoctorService::new(&git, &state, &stack);
+            assert_eq!(service.forge_label(), "forge");
         }
 
         #[test]

--- a/crates/rung-cli/src/services/submit.rs
+++ b/crates/rung-cli/src/services/submit.rs
@@ -115,7 +115,7 @@ where
     H: ForgeApi,
 {
     git: &'a G,
-    github: &'a H,
+    forge: &'a H,
     repo: RepoId,
 }
 
@@ -126,8 +126,8 @@ where
     H: ForgeApi,
 {
     /// Create a new submit service.
-    pub const fn new(git: &'a G, github: &'a H, repo: RepoId) -> Self {
-        Self { git, github, repo }
+    pub const fn new(git: &'a G, forge: &'a H, repo: RepoId) -> Self {
+        Self { git, forge, repo }
     }
 
     /// Create a submit plan by analyzing the stack and checking existing PRs.
@@ -137,7 +137,7 @@ where
     /// that when creating PRs, the base branch always exists on the remote.
     ///
     /// # Errors
-    /// Returns error if GitHub API calls fail.
+    /// Returns error if forge API calls fail.
     pub async fn create_plan(
         &self,
         stack: &Stack,
@@ -159,16 +159,25 @@ where
 
             // Check if PR already exists
             if let Some(pr_number) = branch.pr {
-                let pr_url = format!("https://github.com/{}/pull/{pr_number}", self.repo);
+                // Fetch the PR to get its forge-provided URL rather than
+                // constructing one, which would be wrong for GitLab (different
+                // host and `/-/merge_requests/` path).
+                let pr = self
+                    .forge
+                    .get_pr(&self.repo, pr_number)
+                    .await
+                    .with_context(|| {
+                        format!("Failed to fetch PR #{pr_number} for '{branch_name}'")
+                    })?;
                 actions.push(PlannedBranchAction::Update {
                     branch: branch_name.to_string(),
                     pr_number,
-                    pr_url,
+                    pr_url: pr.html_url,
                     base: base_branch,
                 });
             } else {
                 let existing = self
-                    .github
+                    .forge
                     .find_pr_for_branch(&self.repo, branch_name)
                     .await
                     .context("Failed to check for existing PR")?;
@@ -207,7 +216,7 @@ where
     /// Returns information about each submitted branch.
     ///
     /// # Errors
-    /// Returns error if git or GitHub operations fail.
+    /// Returns error if git or forge operations fail.
     pub async fn execute(
         &self,
         stack: &mut Stack,
@@ -235,7 +244,7 @@ where
                         body: None,
                         base: Some(base.clone()),
                     };
-                    self.github
+                    self.forge
                         .update_pr(&self.repo, *pr_number, update)
                         .await
                         .with_context(|| format!("Failed to update PR #{pr_number}"))?;
@@ -269,7 +278,7 @@ where
 
                     // Check if PR was created between planning and execution
                     let existing = self
-                        .github
+                        .forge
                         .find_pr_for_branch(&self.repo, branch)
                         .await
                         .context("Failed to check for existing PR")?;
@@ -281,7 +290,7 @@ where
                             body: None,
                             base: Some(base.clone()),
                         };
-                        self.github
+                        self.forge
                             .update_pr(&self.repo, pr.number, update)
                             .await
                             .with_context(|| format!("Failed to update PR #{}", pr.number))?;
@@ -297,7 +306,7 @@ where
                             draft: *draft,
                         };
                         let pr = self
-                            .github
+                            .forge
                             .create_pr(&self.repo, create)
                             .await
                             .with_context(|| format!("Failed to create PR for {branch}"))?;
@@ -332,7 +341,7 @@ where
     /// Update stack navigation comments on all PRs.
     ///
     /// # Errors
-    /// Returns error if GitHub API calls fail.
+    /// Returns error if forge API calls fail.
     pub async fn update_stack_comments(&self, stack: &Stack, default_branch: &str) -> Result<()> {
         for branch in &stack.branches {
             let Some(pr_number) = branch.pr else {
@@ -343,7 +352,7 @@ where
 
             // Find existing rung comment
             let comments = self
-                .github
+                .forge
                 .list_pr_comments(&self.repo, pr_number)
                 .await
                 .with_context(|| format!("Failed to list comments on PR #{pr_number}"))?;
@@ -356,13 +365,13 @@ where
 
             if let Some(comment) = existing_comment {
                 let update = UpdateComment { body: comment_body };
-                self.github
+                self.forge
                     .update_pr_comment(&self.repo, pr_number, comment.id, update)
                     .await
                     .with_context(|| format!("Failed to update comment on PR #{pr_number}"))?;
             } else {
                 let create = CreateComment { body: comment_body };
-                self.github
+                self.forge
                     .create_pr_comment(&self.repo, pr_number, create)
                     .await
                     .with_context(|| format!("Failed to create comment on PR #{pr_number}"))?;
@@ -1086,7 +1095,20 @@ mod tests {
                 number: u64,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
             {
-                async move { Err(rung_github::Error::PrNotFound(number)) }
+                async move {
+                    Ok(rung_github::PullRequest {
+                        number,
+                        title: "Existing".to_string(),
+                        body: None,
+                        state: rung_github::PullRequestState::Open,
+                        base_branch: "main".to_string(),
+                        head_branch: "feature".to_string(),
+                        html_url: format!("https://github.com/test/repo/pull/{number}"),
+                        mergeable: None,
+                        mergeable_state: None,
+                        draft: false,
+                    })
+                }
             }
 
             fn get_prs_batch(
@@ -1308,6 +1330,14 @@ mod tests {
             let plan = service.create_plan(&stack, &config).await.unwrap();
             assert_eq!(plan.count_creates(), 0);
             assert_eq!(plan.count_updates(), 1);
+
+            // The URL must come from the forge (mock returns "test/repo"), not be
+            // fabricated from the RepoId ("owner/repo") — the latter would be
+            // wrong on GitLab.
+            let PlannedBranchAction::Update { pr_url, .. } = &plan.actions[0] else {
+                panic!("expected an Update action");
+            };
+            assert_eq!(pr_url, "https://github.com/test/repo/pull/42");
         }
 
         #[tokio::test]

--- a/crates/rung-cli/src/services/submit.rs
+++ b/crates/rung-cli/src/services/submit.rs
@@ -149,6 +149,17 @@ where
         // are pushed before PRs that depend on them are created.
         let sorted_branches = topological_sort(&stack.branches, &config.default_branch)?;
 
+        // Fetch all already-tracked PRs in a single batch (one round-trip) so we
+        // can reuse each PR's forge-provided URL instead of constructing one,
+        // which would be wrong for GitLab (different host and
+        // `/-/merge_requests/` path).
+        let tracked_prs: Vec<u64> = sorted_branches.iter().filter_map(|b| b.pr).collect();
+        let existing_prs = self
+            .forge
+            .get_prs_batch(&self.repo, &tracked_prs)
+            .await
+            .context("Failed to fetch existing PRs")?;
+
         for branch in sorted_branches {
             let branch_name = &branch.name;
             let base_branch = branch
@@ -159,20 +170,13 @@ where
 
             // Check if PR already exists
             if let Some(pr_number) = branch.pr {
-                // Fetch the PR to get its forge-provided URL rather than
-                // constructing one, which would be wrong for GitLab (different
-                // host and `/-/merge_requests/` path).
-                let pr = self
-                    .forge
-                    .get_pr(&self.repo, pr_number)
-                    .await
-                    .with_context(|| {
-                        format!("Failed to fetch PR #{pr_number} for '{branch_name}'")
-                    })?;
+                let pr = existing_prs.get(&pr_number).ok_or_else(|| {
+                    anyhow::anyhow!("PR #{pr_number} for '{branch_name}' not found on the forge")
+                })?;
                 actions.push(PlannedBranchAction::Update {
                     branch: branch_name.to_string(),
                     pr_number,
-                    pr_url: pr.html_url,
+                    pr_url: pr.html_url.clone(),
                     base: base_branch,
                 });
             } else {
@@ -1095,32 +1099,42 @@ mod tests {
                 number: u64,
             ) -> impl std::future::Future<Output = rung_github::Result<rung_github::PullRequest>> + Send
             {
-                async move {
-                    Ok(rung_github::PullRequest {
-                        number,
-                        title: "Existing".to_string(),
-                        body: None,
-                        state: rung_github::PullRequestState::Open,
-                        base_branch: "main".to_string(),
-                        head_branch: "feature".to_string(),
-                        html_url: format!("https://github.com/test/repo/pull/{number}"),
-                        mergeable: None,
-                        mergeable_state: None,
-                        draft: false,
-                    })
-                }
+                async move { Err(rung_github::Error::PrNotFound(number)) }
             }
 
             fn get_prs_batch(
                 &self,
                 _repo: &rung_github::RepoId,
-                _numbers: &[u64],
+                numbers: &[u64],
             ) -> impl std::future::Future<
                 Output = rung_github::Result<
                     std::collections::HashMap<u64, rung_github::PullRequest>,
                 >,
             > + Send {
-                async { Ok(std::collections::HashMap::new()) }
+                let numbers = numbers.to_vec();
+                async move {
+                    let map = numbers
+                        .into_iter()
+                        .map(|number| {
+                            (
+                                number,
+                                rung_github::PullRequest {
+                                    number,
+                                    title: "Existing".to_string(),
+                                    body: None,
+                                    state: rung_github::PullRequestState::Open,
+                                    base_branch: "main".to_string(),
+                                    head_branch: "feature".to_string(),
+                                    html_url: format!("https://github.com/test/repo/pull/{number}"),
+                                    mergeable: None,
+                                    mergeable_state: None,
+                                    draft: false,
+                                },
+                            )
+                        })
+                        .collect();
+                    Ok(map)
+                }
             }
 
             fn find_pr_for_branch(

--- a/crates/rung-cli/src/services/submit.rs
+++ b/crates/rung-cli/src/services/submit.rs
@@ -170,13 +170,27 @@ where
 
             // Check if PR already exists
             if let Some(pr_number) = branch.pr {
-                let pr = existing_prs.get(&pr_number).ok_or_else(|| {
-                    anyhow::anyhow!("PR #{pr_number} for '{branch_name}' not found on the forge")
-                })?;
+                // Prefer the batched result. If the batch omitted this PR (it can
+                // skip nodes on a partial forge error, not only when a PR is
+                // absent), fall back to an individual fetch so the user sees the
+                // real underlying error (404 vs auth vs rate limit) rather than a
+                // generic "not found".
+                let pr_url = match existing_prs.get(&pr_number) {
+                    Some(pr) => pr.html_url.clone(),
+                    None => {
+                        self.forge
+                            .get_pr(&self.repo, pr_number)
+                            .await
+                            .with_context(|| {
+                                format!("Failed to fetch PR #{pr_number} for '{branch_name}'")
+                            })?
+                            .html_url
+                    }
+                };
                 actions.push(PlannedBranchAction::Update {
                     branch: branch_name.to_string(),
                     pr_number,
-                    pr_url: pr.html_url.clone(),
+                    pr_url,
                     base: base_branch,
                 });
             } else {
@@ -1076,18 +1090,27 @@ mod tests {
         // Mock ForgeApi for submit testing
         struct MockGitHubClient {
             find_pr_result: Option<rung_github::PullRequest>,
+            /// When true, `get_prs_batch` returns an empty map, forcing the
+            /// per-PR `get_pr` fallback in `create_plan`.
+            empty_batch: bool,
         }
 
         impl MockGitHubClient {
             fn new() -> Self {
                 Self {
                     find_pr_result: None,
+                    empty_batch: false,
                 }
             }
 
             #[allow(dead_code)]
             fn with_existing_pr(mut self, pr: rung_github::PullRequest) -> Self {
                 self.find_pr_result = Some(pr);
+                self
+            }
+
+            fn with_empty_batch(mut self) -> Self {
+                self.empty_batch = true;
                 self
             }
         }
@@ -1111,7 +1134,11 @@ mod tests {
                     std::collections::HashMap<u64, rung_github::PullRequest>,
                 >,
             > + Send {
-                let numbers = numbers.to_vec();
+                let numbers = if self.empty_batch {
+                    Vec::new()
+                } else {
+                    numbers.to_vec()
+                };
                 async move {
                     let map = numbers
                         .into_iter()
@@ -1352,6 +1379,37 @@ mod tests {
                 panic!("expected an Update action");
             };
             assert_eq!(pr_url, "https://github.com/test/repo/pull/42");
+        }
+
+        #[tokio::test]
+        async fn test_create_plan_falls_back_to_get_pr_when_batch_omits() {
+            // When the batch omits a tracked PR (e.g. a partial forge error, not
+            // just an absent PR), create_plan must fall back to a per-PR fetch so
+            // the real error surfaces rather than a generic "not found".
+            let oid = Oid::zero();
+            let git = MockGitOps::new()
+                .with_branch("main", oid)
+                .with_branch("feature/a", oid);
+            let github = MockGitHubClient::new().with_empty_batch();
+
+            let service = SubmitService::new(&git, &github, RepoId::new("owner/repo"));
+
+            let mut stack = Stack::default();
+            let mut branch = StackBranch::try_new("feature/a", None::<&str>).unwrap();
+            branch.pr = Some(42);
+            stack.add_branch(branch);
+
+            let config = SubmitConfig {
+                draft: false,
+                custom_title: None,
+                current_branch: None,
+                default_branch: "main".to_string(),
+            };
+
+            // The mock's get_pr returns PrNotFound(42); the fallback surfaces it
+            // with per-PR context rather than swallowing it.
+            let err = service.create_plan(&stack, &config).await.unwrap_err();
+            assert!(err.to_string().contains("Failed to fetch PR #42"));
         }
 
         #[tokio::test]

--- a/crates/rung-cli/src/services/test_mocks.rs
+++ b/crates/rung-cli/src/services/test_mocks.rs
@@ -24,6 +24,7 @@ pub struct MockGitOps {
     pub push_results: RefCell<HashMap<String, bool>>,
     pub has_staged_changes: RefCell<bool>,
     pub rebase_should_fail: RefCell<bool>,
+    pub origin_url: RefCell<String>,
 }
 
 impl Default for MockGitOps {
@@ -44,7 +45,14 @@ impl MockGitOps {
             push_results: RefCell::new(HashMap::new()),
             has_staged_changes: RefCell::new(false),
             rebase_should_fail: RefCell::new(false),
+            origin_url: RefCell::new("https://github.com/test/repo.git".to_string()),
         }
+    }
+
+    #[allow(dead_code)]
+    pub fn with_origin_url(self, url: &str) -> Self {
+        *self.origin_url.borrow_mut() = url.to_string();
+        self
     }
 
     #[allow(dead_code)]
@@ -242,7 +250,7 @@ impl GitOps for MockGitOps {
     }
 
     fn origin_url(&self) -> GitResult<String> {
-        Ok("https://github.com/test/repo.git".to_string())
+        Ok(self.origin_url.borrow().clone())
     }
 
     fn remote_divergence(&self, branch: &str) -> GitResult<RemoteDivergence> {

--- a/site/src/content/docs/commands/doctor.md
+++ b/site/src/content/docs/commands/doctor.md
@@ -36,10 +36,12 @@ rung doctor --json
 - **Branches need rebasing** — Which branches are out of sync
 - **Sync operations in progress** — Interrupted syncs that need attention
 
-### GitHub Connectivity
+### Forge Connectivity
 
-- **Authentication** — GitHub auth is configured and working
-- **PR status** — PRs are open/closed/merged correctly
+Works with both GitHub and GitLab — the check targets whichever forge your `origin` remote points at, and the progress line names it (e.g. `Checking GitLab...`).
+
+- **Authentication** — forge auth is configured and working (GitHub `gh`/`GITHUB_TOKEN`, or GitLab `glab`/`GITLAB_TOKEN`)
+- **PR/MR status** — pull requests (GitHub) or merge requests (GitLab) are open/closed/merged correctly
 
 ## Example Output
 
@@ -48,33 +50,34 @@ rung doctor --json
 ```bash
 $ rung doctor
 
-✓ Stack integrity: OK
-✓ Git state: clean
-✓ Sync state: all branches synced
-✓ GitHub: connected, 3 PRs open
+  Checking rung initialization... ✓
+  Checking git state... ✓
+  Checking stack integrity... ✓
+  Checking sync state... ✓
+  Checking GitHub... ✓
 
-No issues found.
+✓ No issues found!
 ```
+
+(On a GitLab repository, the last check line reads `Checking GitLab... ✓`.)
 
 ### Issues Found
 
 ```bash
 $ rung doctor
 
-✓ Stack integrity: OK
-⚠ Git state: uncommitted changes in 2 files
-✗ Sync state: 2 branches need rebasing
-✓ GitHub: connected
+  Checking rung initialization... ✓
+  Checking git state... ⚠
+  Checking stack integrity... ✓
+  Checking sync state... ✗
+  Checking GitLab... ✓
 
-Issues:
-  warning: Uncommitted changes detected
+  ⚠ Uncommitted changes detected
     → Commit or stash changes before syncing
-
-  error: feat-add-user-api is 3 commits behind parent
+  ✗ feat-add-user-api is 3 commits behind parent
     → Run `rung sync` to update
 
-  error: feat-add-user-tests is 1 commit behind parent
-    → Run `rung sync` to update
+✗ Found 2 issue(s) (1 error(s), 1 warning(s))
 ```
 
 ## Issue Severities
@@ -91,45 +94,29 @@ Issues:
 $ rung doctor --json
 ```
 
+The `--json` output is a flat report: overall health, error/warning counts, and a single list of issues aggregated across all checks (git state, stack integrity, sync state, and forge connectivity). It is forge-neutral — issue messages name the forge where relevant.
+
 ```json
 {
-  "stack_integrity": {
-    "status": "ok",
-    "issues": []
-  },
-  "git_state": {
-    "status": "warning",
-    "issues": [
-      {
-        "severity": "warning",
-        "message": "Uncommitted changes detected",
-        "suggestion": "Commit or stash changes before syncing",
-        "files": ["src/main.rs", "Cargo.toml"]
-      }
-    ]
-  },
-  "sync_state": {
-    "status": "error",
-    "issues": [
-      {
-        "severity": "error",
-        "branch": "feat-add-user-api",
-        "message": "3 commits behind parent",
-        "suggestion": "Run `rung sync` to update"
-      }
-    ]
-  },
-  "github": {
-    "status": "ok",
-    "authenticated": true,
-    "prs": {
-      "open": 3,
-      "merged": 1,
-      "closed": 0
+  "healthy": false,
+  "errors": 1,
+  "warnings": 1,
+  "issues": [
+    {
+      "severity": "warning",
+      "message": "Uncommitted changes detected",
+      "suggestion": "Commit or stash changes before syncing"
+    },
+    {
+      "severity": "error",
+      "message": "feat-add-user-api is 3 commits behind parent",
+      "suggestion": "Run `rung sync` to update"
     }
-  }
+  ]
 }
 ```
+
+Each issue has a `severity` (`error` or `warning`) and `message`; `suggestion` is present only when there's a recommended fix.
 
 ## Common Issues and Solutions
 
@@ -173,18 +160,24 @@ rung sync
 git checkout -b feat-old origin/feat-old
 ```
 
-### GitHub Authentication Failed
+### Forge Authentication Failed
 
 ```
-✗ GitHub: authentication failed
+  ✗ GitHub authentication failed
 ```
 
-**Solution:** Re-authenticate:
+The message names the detected forge — on a GitLab remote it reads `GitLab authentication failed`.
+
+**Solution:** Re-authenticate with the matching forge:
 
 ```bash
+# GitHub
 gh auth login
-# or set GITHUB_TOKEN
-export GITHUB_TOKEN=ghp_...
+# or: export GITHUB_TOKEN=ghp_...
+
+# GitLab
+glab auth login
+# or: export GITLAB_TOKEN=glpat_...
 ```
 
 ### Sync In Progress


### PR DESCRIPTION
## Summary

Make `rung doctor`'s connectivity output forge-aware, and remove remaining GitHub-specific assumptions from the CLI now that GitLab is supported.

Fixes #185.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — n/a; updated `docs/commands/doctor.md`
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Bug fix
- **Current behavior**:
  - `rung doctor` always prints `Checking GitHub...` regardless of the remote's forge.
  - `rung submit` displays a fabricated `https://github.com/<repo>/pull/<n>` URL for already-submitted branches — wrong host **and** wrong path (`/-/merge_requests/`) on GitLab. This is user-facing and appears in `--json`.
  - Various `--help` text, an output string, and a forge-generic field (`SubmitService.github`) still read as GitHub-only.
- **New behavior**:
  - `doctor` prints `Checking <forge>...` via a best-effort `forge_label()` (GitHub / GitLab / `forge` fallback for no-origin or unrecognized remotes). The auth-failure message was already forge-aware.
  - `submit` uses the forge-provided `html_url` (fetched via `get_pr`) instead of constructing a URL, so it's correct for GitHub and GitLab.
  - Forge-neutral `--help` text (sync/merge/doctor), the sync progress string, doc comments, and the renamed `SubmitService.forge` field.
- **Breaking changes?**: No.

## Notes

- **The `--json` premise in #185 was already satisfied** — `DiagnosticReport` never derived `Serialize`; the actual `--json` output is a flat `{healthy, errors, warnings, issues}` with no `github` key. So no JSON shape change was needed; `doctor.md`'s Example/JSON blocks (which were fabricated and matched neither the real human nor JSON output) were corrected to reflect reality.
- The submit URL fix trades the old "skip a fetch for known PRs" shortcut for one `get_pr` call per already-submitted branch during planning — necessary to obtain a correct URL forge-neutrally, and consistent with the sibling branch that already fetches via `find_pr_for_branch`.
- Internal rename `check_github` → `check_forge`, `DiagnosticReport.github` → `forge`, `SubmitService.github` → `forge` (all internal; not serialized, not public API).
- Left intentionally: the test-only `MockGitHubClient` name — it's a legitimately GitHub-shaped test mock.

## Testing

`cargo test --workspace` passes (added `forge_label` unit tests + a submit test asserting the URL comes from the forge, not the RepoId). `cargo +1.88 clippy --all-targets --all-features -- -D warnings` and `cargo +1.88 fmt --check` are clean (lint runs on MSRV). Smoke-tested `rung doctor` against GitHub/GitLab/unrecognized remotes:

```
GitLab remote        →  Checking GitLab... ✗
GitHub remote        →  Checking GitHub... ✓
Unrecognized remote  →  Checking forge... ⚠
```
