### PR TITLE
fix(gitlab): forge-neutralize CLI — MR references, output wording, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![MSRV](https://img.shields.io/badge/MSRV-1.88-orange.svg)](https://www.rust-lang.org)
 
-A Git workflow tool for managing stacked PRs (pull request chains).
+A Git workflow tool for managing stacked pull requests (GitHub) and merge requests (GitLab) — chains of dependent branches.
 
 ![Demo](https://raw.githubusercontent.com/auswm85/rung/main/assets/demo.gif)
 
@@ -19,7 +19,7 @@ Rung helps you work with dependent branches by:
 
 - Tracking branch relationships in a stack
 - Syncing child branches when parents are updated
-- Managing PR chains on GitHub with automatic stack comments
+- Managing PR/MR chains on GitHub and GitLab (including self-hosted GitLab) with automatic stack comments
 - Handling merges with automatic descendant rebasing
 
 ## Installation
@@ -183,7 +183,7 @@ rung sync --abort
 
 **Options:**
 
-- `--check` - Predict conflicts without performing sync *(v0.8.0+)*
+- `--check` - Predict conflicts without performing sync _(v0.8.0+)_
 - `--dry-run` - Show what would be done without making changes
 - `--continue` - Continue after resolving conflicts
 - `--abort` - Abort and restore from backup
@@ -191,7 +191,7 @@ rung sync --abort
 
 ### `rung submit`
 
-Push all stack branches and create/update PRs on GitHub. Each PR includes a stack comment showing the branch hierarchy.
+Push all stack branches and create/update pull requests (GitHub) or merge requests (GitLab). Each PR/MR includes a stack comment showing the branch hierarchy.
 
 ```bash
 rung submit                          # Submit all branches
@@ -208,15 +208,15 @@ rung submit -m "commit message"      # Create new commit with uncommitted change
 - `--draft` - Create PRs as drafts
 - `--force` - Force push using `--force-with-lease` for safety, even if remote has changes
 - `-t, --title <title>` - Custom PR title for current branch (overrides commit message)
-- `--amend` - Amend staged/unstaged changes to the current commit before pushing *(v0.8.0+)*
-- `-m, --message <message>` - Create a new commit with the given message before pushing *(v0.8.0+)*
+- `--amend` - Amend staged/unstaged changes to the current commit before pushing _(v0.8.0+)_
+- `-m, --message <message>` - Create a new commit with the given message before pushing _(v0.8.0+)_
 
 ### `rung merge`
 
-Merge the current branch's PR via GitHub API. Automatically:
+Merge the current branch's PR/MR via the forge API (GitHub or GitLab). Automatically:
 
 - Rebases all descendant branches onto the new base
-- Updates PR bases on GitHub
+- Updates PR/MR bases on the forge
 - Removes the branch from the stack
 - Deletes local and remote branches
 - Pulls latest changes to keep local up to date
@@ -374,7 +374,7 @@ Diagnose issues with the stack and repository. Checks:
 - **Stack integrity**: Branches exist, parents are valid, no circular dependencies
 - **Git state**: Clean working directory, not detached HEAD, no rebase in progress
 - **Sync state**: Branches that need rebasing, sync operations in progress
-- **GitHub connectivity**: Authentication, PR status (open/closed/merged)
+- **Forge connectivity**: Authentication and PR/MR status (open/closed/merged) on GitHub or GitLab
 
 ```bash
 rung doctor
@@ -439,7 +439,9 @@ Rung stores its state in `.git/rung/`:
 
 - Rust 1.88+
 - Git 2.x
-- GitHub CLI (`gh`) authenticated, or `GITHUB_TOKEN` environment variable
+- A forge credential for your remote:
+  - **GitHub** — GitHub CLI (`gh`) authenticated, or `GITHUB_TOKEN` environment variable
+  - **GitLab** — GitLab CLI (`glab`) authenticated, or `GITLAB_TOKEN` environment variable. For a self-hosted instance, set `gitlab.api_url` in `.git/rung/config.toml`.
 
 ## Project Structure
 
@@ -450,7 +452,7 @@ crates/
   rung-git/      # Git operations wrapper
   rung-forge/    # Forge-neutral contract (ForgeApi trait, remote detection)
   rung-github/   # GitHub backend
-  rung-gitlab/   # GitLab backend (in progress)
+  rung-gitlab/   # GitLab backend
 ```
 
 ## Development

--- a/crates/rung-cli/src/commands/merge.rs
+++ b/crates/rung-cli/src/commands/merge.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use anyhow::{Context, Result, bail};
 use rung_core::State;
 use rung_core::stack::Stack;
+use rung_forge::{ForgeApi, MergeMethod, RepoId};
 use rung_git::{Oid, Repository};
-use rung_github::{MergeMethod, RepoId};
 
 use crate::forge::Forge;
 use serde::Serialize;
@@ -142,10 +142,10 @@ pub fn run(json: bool, method: &str, no_delete: bool) -> Result<()> {
     let (ctx, stack) = setup_merge_context(&repo, &state)?;
 
     if !json {
-        output::info(&format!(
-            "Merging PR #{} for {}...",
-            ctx.pr_number, ctx.current_branch
-        ));
+        // Forge-agnostic: the forge client (which knows PR vs MR) is created in
+        // execute_merge, so reference the branch here and let the success
+        // message carry the forge-specific "PR #N" / "MR !N".
+        output::info(&format!("Merging '{}'...", ctx.current_branch));
     }
 
     let rt = tokio::runtime::Runtime::new()?;
@@ -217,7 +217,12 @@ async fn execute_merge(
     }
 
     if !json {
-        output::success(&format!("Merged PR #{}", ctx.pr_number));
+        output::success(&format!(
+            "Merged {} {}{}",
+            client.pr_noun(),
+            client.pr_reference_prefix(),
+            ctx.pr_number
+        ));
     }
 
     // NOTE: After merge_pr succeeds, the PR/MR is merged on the forge.

--- a/crates/rung-cli/src/commands/status.rs
+++ b/crates/rung-cli/src/commands/status.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use rung_core::State;
+use rung_forge::{ForgeApi, PullRequestState};
 use rung_git::Repository;
-use rung_github::{ForgeApi, PullRequestState};
 
 use crate::forge::Forge;
 use serde::Serialize;
@@ -56,7 +56,7 @@ pub fn run(json: bool, fetch: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Fetch PR statuses if requested (best-effort - don't fail status command on GitHub errors)
+    // Fetch PR/MR statuses if requested (best-effort - don't fail status command on forge errors)
     let mut pr_cache = HashMap::new();
     if fetch
         && let Err(e) = fetch_pr_statuses(&repo, &stack, &state.load_config()?, &mut pr_cache, json)
@@ -109,7 +109,7 @@ pub fn run(json: bool, fetch: bool) -> Result<()> {
     Ok(())
 }
 
-/// Fetch PR statuses from GitHub (best-effort).
+/// Fetch PR/MR statuses from the forge (best-effort).
 fn fetch_pr_statuses(
     repo: &Repository,
     stack: &rung_core::Stack,
@@ -132,7 +132,12 @@ fn fetch_pr_statuses(
     let rt = tokio::runtime::Runtime::new()?;
 
     if !json {
-        let label = if pr_numbers.len() == 1 { "PR" } else { "PRs" };
+        let noun = client.pr_noun();
+        let label = if pr_numbers.len() == 1 {
+            noun.to_string()
+        } else {
+            format!("{noun}s")
+        };
         output::info(&format!(
             "Fetching status for {} {label}...",
             pr_numbers.len(),

--- a/crates/rung-cli/src/commands/submit.rs
+++ b/crates/rung-cli/src/commands/submit.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result, bail};
 use inquire::{Select, Text};
 use rung_core::{State, stack::Stack, sync};
+use rung_forge::ForgeApi;
 use rung_git::{RemoteDivergence, Repository};
 
 use crate::forge::Forge;
@@ -145,16 +146,17 @@ pub fn run(
 
     // Print progress for each result
     if !json {
+        let (noun, refp) = (client.pr_noun(), client.pr_reference_prefix());
         for result in &results {
             match result.action {
                 SubmitAction::Created => {
                     output::success(&format!(
-                        "  Created PR #{}: {}",
+                        "  Created {noun} {refp}{}: {}",
                         result.pr_number, result.pr_url
                     ));
                 }
                 SubmitAction::Updated => {
-                    output::info(&format!("  Updated PR #{}", result.pr_number));
+                    output::info(&format!("  Updated {noun} {refp}{}", result.pr_number));
                 }
             }
         }

--- a/crates/rung-cli/src/commands/sync.rs
+++ b/crates/rung-cli/src/commands/sync.rs
@@ -1,10 +1,10 @@
 //! `rung sync` command - Sync the stack by rebasing all branches.
 //!
 //! This command performs a full sync operation:
-//! 1. Detects PRs merged externally (via GitHub UI)
+//! 1. Detects PRs/MRs merged externally (via the forge's web UI)
 //! 2. Updates stack topology for merged branches
 //! 3. Rebases remaining branches onto their new parents
-//! 4. Updates GitHub PR base branches
+//! 4. Updates PR/MR base branches on the forge
 //! 5. Pushes all synced branches
 
 use anyhow::{Context, Result, bail};
@@ -12,8 +12,8 @@ use rung_core::sync::{
     self, ReconcileResult, SyncConflictPrediction, SyncResult, predict_sync_conflicts,
 };
 use rung_core::{Config, State};
+use rung_forge::{ForgeApi, RepoId};
 use rung_git::Repository;
-use rung_github::{ForgeApi, RepoId};
 use serde::Serialize;
 
 use crate::forge::Forge;
@@ -118,12 +118,12 @@ pub fn run(
         bail!("Cannot use --continue and --abort together");
     }
 
-    // Handle abort (no GitHub needed)
+    // Handle abort (no forge needed)
     if abort {
         return handle_abort(&repo, &state, json);
     }
 
-    // Handle continue (no GitHub needed)
+    // Handle continue (no forge needed)
     if continue_ {
         return handle_continue(&repo, &state, json, no_push);
     }
@@ -307,7 +307,7 @@ fn run_sync_phases(
     no_push: bool,
     forge_auth_unavailable: bool,
 ) -> Result<()> {
-    // Create SyncService once if GitHub is available
+    // Create SyncService once if the forge client is available
     let service = match (client, forge_info) {
         (Some(client), Some(repo_id)) => Some(SyncService::new(repo, client, repo_id.clone())),
         _ => None,
@@ -471,7 +471,7 @@ fn execute_sync_plan(
     }
 }
 
-/// Phase 4 & 5: Update PR bases on GitHub and push branches.
+/// Phase 4 & 5: Update PR/MR bases on the forge and push branches.
 fn run_phase_finalize(
     service: Option<&SyncService<'_, Repository, Forge>>,
     state: &State,

--- a/crates/rung-cli/src/forge.rs
+++ b/crates/rung-cli/src/forge.rs
@@ -264,6 +264,20 @@ impl ForgeApi for Forge {
             }
         }
     }
+
+    fn pr_reference_prefix(&self) -> &'static str {
+        match self {
+            Self::GitHub(c) => ForgeApi::pr_reference_prefix(c),
+            Self::GitLab(c) => ForgeApi::pr_reference_prefix(c),
+        }
+    }
+
+    fn pr_noun(&self) -> &'static str {
+        match self {
+            Self::GitHub(c) => ForgeApi::pr_noun(c),
+            Self::GitLab(c) => ForgeApi::pr_noun(c),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/rung-cli/src/services/absorb.rs
+++ b/crates/rung-cli/src/services/absorb.rs
@@ -6,8 +6,8 @@
 use anyhow::{Context, Result};
 use rung_core::StateStore;
 use rung_core::absorb::{self, AbsorbPlan, AbsorbResult};
+use rung_forge::ForgeApi;
 use rung_git::AbsorbOps;
-use rung_github::ForgeApi;
 
 use crate::forge::Forge;
 

--- a/crates/rung-cli/src/services/doctor.rs
+++ b/crates/rung-cli/src/services/doctor.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 
 use anyhow::{Context, Result};
 use rung_core::Stack;
-use rung_github::{ForgeApi, PullRequestState};
+use rung_forge::{ForgeApi, PullRequestState};
 
 use crate::forge::Forge;
 use serde::Serialize;
@@ -405,16 +405,22 @@ impl<'a, G: rung_git::GitOps, S: rung_core::StateStore> DoctorService<'a, G, S> 
                     };
                     result.issues.push(
                         Issue::warning(format!(
-                            "PR #{} for '{}' is {state_str} (not open)",
-                            pr_number, branch.name
+                            "{} {}{} for '{}' is {state_str} (not open)",
+                            client.pr_noun(),
+                            client.pr_reference_prefix(),
+                            pr_number,
+                            branch.name
                         ))
                         .with_suggestion("Run `rung sync` to clean up or merge the branch"),
                     );
                 }
                 Err(e) => {
                     result.issues.push(Issue::warning(format!(
-                        "Could not fetch PR #{} for '{}': {e}",
-                        pr_number, branch.name
+                        "Could not fetch {} {}{} for '{}': {e}",
+                        client.pr_noun(),
+                        client.pr_reference_prefix(),
+                        pr_number,
+                        branch.name
                     )));
                 }
             }

--- a/crates/rung-cli/src/services/merge.rs
+++ b/crates/rung-cli/src/services/merge.rs
@@ -8,8 +8,8 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use anyhow::{Context, Result, bail};
 use rung_core::stack::Stack;
 use rung_core::{BranchName, StateStore};
+use rung_forge::{ForgeApi, MergeMethod, MergePullRequest, RepoId, UpdatePullRequest};
 use rung_git::{GitOps, Oid};
-use rung_github::{ForgeApi, MergeMethod, MergePullRequest, RepoId, UpdatePullRequest};
 
 /// Information about a descendant branch that was processed.
 #[derive(Debug, Clone)]
@@ -43,7 +43,7 @@ impl<'a, G: GitOps, H: ForgeApi> MergeService<'a, G, H> {
 
     /// Validate that a PR is mergeable.
     ///
-    /// GitHub may return `mergeable: None` while computing merge status.
+    /// The forge may return `mergeable: None` while computing merge status.
     /// This method polls until `mergeable` becomes `Some(true)` or retries exhaust.
     pub async fn validate_mergeable(&self, pr_number: u64) -> Result<rung_github::PullRequest> {
         const MAX_RETRIES: u32 = 5;
@@ -155,7 +155,7 @@ impl<'a, G: GitOps, H: ForgeApi> MergeService<'a, G, H> {
         failures
     }
 
-    /// Merge a PR on GitHub.
+    /// Merge a PR/MR on the forge.
     pub async fn merge_pr(&self, pr_number: u64, merge_method: MergeMethod) -> Result<()> {
         let merge_request = MergePullRequest {
             commit_title: None,

--- a/crates/rung-cli/src/services/submit.rs
+++ b/crates/rung-cli/src/services/submit.rs
@@ -8,10 +8,10 @@ use std::fmt::Write;
 
 use anyhow::{Context, Result, bail};
 use rung_core::stack::Stack;
-use rung_git::GitOps;
-use rung_github::{
+use rung_forge::{
     CreateComment, CreatePullRequest, ForgeApi, RepoId, UpdateComment, UpdatePullRequest,
 };
+use rung_git::GitOps;
 use serde::Serialize;
 
 /// A planned action for a single branch.
@@ -361,12 +361,13 @@ where
     /// # Errors
     /// Returns error if forge API calls fail.
     pub async fn update_stack_comments(&self, stack: &Stack, default_branch: &str) -> Result<()> {
+        let ref_prefix = self.forge.pr_reference_prefix();
         for branch in &stack.branches {
             let Some(pr_number) = branch.pr else {
                 continue;
             };
 
-            let comment_body = generate_stack_comment(stack, pr_number, default_branch);
+            let comment_body = generate_stack_comment(stack, pr_number, default_branch, ref_prefix);
 
             // Find existing rung comment
             let comments = self
@@ -477,7 +478,12 @@ fn find_stack_base<'a>(stack: &'a Stack, branch_name: &str, default_branch: &'a 
 }
 
 /// Generate stack comment for a PR.
-fn generate_stack_comment(stack: &Stack, current_pr: u64, default_branch: &str) -> String {
+fn generate_stack_comment(
+    stack: &Stack,
+    current_pr: u64,
+    default_branch: &str,
+    ref_prefix: &str,
+) -> String {
     let mut comment = String::from(STACK_COMMENT_MARKER);
     comment.push('\n');
 
@@ -492,10 +498,10 @@ fn generate_stack_comment(stack: &Stack, current_pr: u64, default_branch: &str) 
         let pointer = if is_current { " 👈" } else { "" };
 
         if let Some(merged) = stack.find_merged(branch_name) {
-            let _ = writeln!(comment, "* ~~**#{}**~~ ✓{pointer}", merged.pr);
+            let _ = writeln!(comment, "* ~~**{ref_prefix}{}**~~ ✓{pointer}", merged.pr);
         } else if let Some(b) = branches.iter().find(|b| &b.name == branch_name) {
             if let Some(pr_num) = b.pr {
-                let _ = writeln!(comment, "* **#{pr_num}**{pointer}");
+                let _ = writeln!(comment, "* **{ref_prefix}{pr_num}**{pointer}");
             } else {
                 let _ = writeln!(comment, "* *(pending)* `{branch_name}`{pointer}");
             }
@@ -982,11 +988,16 @@ mod tests {
             b.pr = Some(42);
         }
 
-        let comment = generate_stack_comment(&stack, 42, "main");
+        let comment = generate_stack_comment(&stack, 42, "main", "#");
         assert!(comment.contains(STACK_COMMENT_MARKER));
         assert!(comment.contains("#42"));
         assert!(comment.contains("main"));
         assert!(comment.contains("rung"));
+
+        // GitLab references merge requests with `!`, not `#`.
+        let gl_comment = generate_stack_comment(&stack, 42, "main", "!");
+        assert!(gl_comment.contains("!42"));
+        assert!(!gl_comment.contains("#42"));
     }
 
     #[test]
@@ -1017,7 +1028,7 @@ mod tests {
             b.pr = Some(20);
         }
 
-        let comment = generate_stack_comment(&stack, 20, "main");
+        let comment = generate_stack_comment(&stack, 20, "main", "#");
         assert!(comment.contains("#10"));
         assert!(comment.contains("#20"));
         assert!(comment.contains("👈")); // Current PR marker

--- a/crates/rung-cli/src/services/sync.rs
+++ b/crates/rung-cli/src/services/sync.rs
@@ -11,8 +11,8 @@ use rung_core::stack::Stack;
 use rung_core::sync::{
     self, ExternalMergeInfo, ReconcileResult, ReparentedBranch, StaleBranches, SyncPlan, SyncResult,
 };
+use rung_forge::{ForgeApi, PullRequestState, RepoId, UpdatePullRequest};
 use rung_git::GitOps;
-use rung_github::{ForgeApi, PullRequestState, RepoId, UpdatePullRequest};
 
 /// Threshold for switching from individual REST calls to batched GraphQL query.
 const BATCH_THRESHOLD: usize = 5;
@@ -38,7 +38,7 @@ impl<'a, G: GitOps, H: ForgeApi> SyncService<'a, G, H> {
 
     /// Fetch the base branch from remote.
     ///
-    /// Note: Currently unused in CLI (fetch happens before GitHub client is available).
+    /// Note: Currently unused in CLI (fetch happens before the forge client is available).
     /// Kept for API completeness and testability.
     #[allow(dead_code)]
     pub fn fetch_base(&self, base_branch: &str) -> Result<()> {
@@ -50,7 +50,7 @@ impl<'a, G: GitOps, H: ForgeApi> SyncService<'a, G, H> {
     /// Detect merged PRs and validate PR bases.
     ///
     /// This performs two key operations:
-    /// 1. Detects PRs that were merged externally (via GitHub UI)
+    /// 1. Detects PRs/MRs that were merged externally (via the forge's web UI)
     /// 2. Validates that each PR's base branch matches what stack.json expects
     pub async fn detect_and_reconcile_merged<S: StateStore>(
         &self,
@@ -214,7 +214,7 @@ impl<'a, G: GitOps, H: ForgeApi> SyncService<'a, G, H> {
 
     /// Continue an in-progress sync.
     ///
-    /// Note: Currently unused in CLI (continue is handled before GitHub client setup).
+    /// Note: Currently unused in CLI (continue is handled before the forge client setup).
     /// Kept for API completeness and testability.
     #[allow(dead_code)]
     pub fn continue_sync<S: StateStore>(&self, state: &S) -> Result<SyncResult> {
@@ -223,14 +223,14 @@ impl<'a, G: GitOps, H: ForgeApi> SyncService<'a, G, H> {
 
     /// Abort an in-progress sync.
     ///
-    /// Note: Currently unused in CLI (abort is handled before GitHub client setup).
+    /// Note: Currently unused in CLI (abort is handled before the forge client setup).
     /// Kept for API completeness and testability.
     #[allow(dead_code)]
     pub fn abort_sync<S: StateStore>(&self, state: &S) -> Result<()> {
         sync::abort_sync(self.repo, state).map_err(Into::into)
     }
 
-    /// Update GitHub PR base branches for reparented and repaired branches.
+    /// Update PR/MR base branches on the forge for reparented and repaired branches.
     pub async fn update_pr_bases(&self, reconcile_result: &ReconcileResult) -> Result<()> {
         // Collect all PRs that need updating
         let updates_needed: Vec<_> = reconcile_result

--- a/crates/rung-forge/src/traits.rs
+++ b/crates/rung-forge/src/traits.rs
@@ -2,8 +2,8 @@
 //!
 //! This module defines the `ForgeApi` trait which abstracts the pull/merge
 //! request operations a forge backend must provide, enabling dependency
-//! injection, testability, and alternative backends. GitHub is currently the
-//! only implementation, provided by the `rung-github` crate.
+//! injection, testability, and alternative backends. It is implemented by the
+//! `rung-github` and `rung-gitlab` crates.
 
 use std::collections::HashMap;
 
@@ -129,4 +129,24 @@ pub trait ForgeApi: Send + Sync {
         comment_id: u64,
         comment: UpdateComment,
     ) -> impl std::future::Future<Output = Result<IssueComment>> + Send;
+
+    // === Formatting ===
+
+    /// Markdown prefix that references a pull/merge request by number (e.g. in
+    /// stack-navigation comments): `#` on GitHub, `!` on GitLab.
+    ///
+    /// Defaults to `#`; backends that use a different sigil override it. Using
+    /// the wrong prefix links to an unrelated entity (a GitLab `#42` points at
+    /// issue 42, not merge request `!42`).
+    fn pr_reference_prefix(&self) -> &'static str {
+        "#"
+    }
+
+    /// Short noun for a change request in user-facing output: `PR` (pull
+    /// request) on GitHub, `MR` (merge request) on GitLab.
+    ///
+    /// Defaults to `PR`; backends override as needed.
+    fn pr_noun(&self) -> &'static str {
+        "PR"
+    }
 }

--- a/crates/rung-gitlab/src/client.rs
+++ b/crates/rung-gitlab/src/client.rs
@@ -620,6 +620,16 @@ impl ForgeApi for GitLabClient {
         )
         .await
     }
+
+    /// GitLab references merge requests with `!` (a `#` would link to an issue).
+    fn pr_reference_prefix(&self) -> &'static str {
+        "!"
+    }
+
+    /// GitLab calls them merge requests.
+    fn pr_noun(&self) -> &'static str {
+        "MR"
+    }
 }
 
 #[cfg(test)]
@@ -635,6 +645,15 @@ mod tests {
     fn test_client(base_url: &str) -> GitLabClient {
         let auth = Auth::Token(SecretString::from("glpat-test-token"));
         GitLabClient::with_base_url(&auth, base_url).unwrap()
+    }
+
+    #[test]
+    fn test_pr_reference_prefix_is_bang() {
+        // GitLab references merge requests with `!`; `#` would link to an issue.
+        assert_eq!(
+            test_client("https://gitlab.com/api/v4").pr_reference_prefix(),
+            "!"
+        );
     }
 
     /// Standard merge-request response JSON for testing.

--- a/crates/rung-gitlab/src/lib.rs
+++ b/crates/rung-gitlab/src/lib.rs
@@ -6,10 +6,10 @@
 //! # Architecture
 //!
 //! This crate provides the concrete [`GitLabClient`], which implements the
-//! [`ForgeApi`] trait defined in the `rung-forge` contract crate. The forge
-//! types and trait are re-exported here for convenience. Authentication and the
-//! credential-bearing HTTP client are functional today; the merge-request,
-//! pipeline, and comment methods are currently skeletons (see issue #170).
+//! [`ForgeApi`] trait defined in the `rung-forge` contract crate over the GitLab
+//! REST v4 API — merge request CRUD, commit statuses, and notes/comments — for
+//! both gitlab.com and self-hosted instances. The forge types and trait are
+//! re-exported here for convenience.
 //!
 //! # Security
 //!

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,9 +50,9 @@ Rung is a two-component system:
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-`rung-forge` defines the forge-neutral `ForgeApi` contract; `rung-github` (and
-the in-progress `rung-gitlab`) implement it. The CLI selects a backend from the
-detected git remote.
+`rung-forge` defines the forge-neutral `ForgeApi` contract; `rung-github` and
+`rung-gitlab` both implement it. The CLI selects a backend from the detected git
+remote.
 
 ---
 
@@ -99,10 +99,10 @@ rung/
 │   │   │   └── auth.rs           # gh CLI / GITHUB_TOKEN
 │   │   └── Cargo.toml
 │   │
-│   ├── rung-gitlab/              # GitLab backend (in progress)
+│   ├── rung-gitlab/              # GitLab backend
 │   │   ├── src/
 │   │   │   ├── lib.rs
-│   │   │   ├── client.rs         # HTTP client + ForgeApi (stubbed, #170)
+│   │   │   ├── client.rs         # HTTP client + ForgeApi (GitLab REST v4)
 │   │   │   └── auth.rs           # glab CLI / GITLAB_TOKEN
 │   │   └── Cargo.toml
 │   │


### PR DESCRIPTION
## Summary

Finish forge-neutralizing the CLI for 1.0.0 now that GitLab is fully supported: fix a real GitLab correctness bug, make user-facing output forge-aware, and purge documentation/comments that still called GitLab unfinished or assumed GitHub-only. Found during the pre-1.0.0 sweep.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (GitLab support, auth, self-hosted config)
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Bug fix + docs + refactor
- **Current behavior**: Stack comments referenced other entries with `#N` (links to an *issue*, not merge request `!N`, on GitLab); terminal output and docs assumed "PR"/GitHub throughout; README, crate docs, and architecture docs still described GitLab as "in progress"/"stubbed".
- **New behavior**:
  - **Correctness (#1):** `ForgeApi::pr_reference_prefix()` (default `#`, GitLab `!`) is threaded into stack-comment generation so GitLab MRs cross-link correctly.
  - **Output (#8):** `ForgeApi::pr_noun()` ("PR"/"MR"); `submit`, `merge`, `status`, and `doctor` now say e.g. "Merged MR !42" on GitLab.
  - **Docs (#2–#6, #9):** removed stale "skeletons (#170)"/"in progress"/"stubbed"/"GitHub is the only implementation" wording from the `rung-gitlab` crate docs, `rung-forge` trait docs, and `docs/architecture.md`; gave the **README** a full GitLab pass (intro, requirements with `glab`/`GITLAB_TOKEN` and self-hosted `gitlab.api_url`, command descriptions, doctor, crate list); generalized stale GitHub-only code comments and `CLAUDE.md`.
  - **Hygiene (#10):** the forge-neutral CLI now imports contract types (`ForgeApi`, `RepoId`, `PullRequestState`, …) from `rung_forge` instead of the `rung_github` re-export shim.
- **Breaking changes?**: No.

## Out of scope

`--json` field naming (`pr_number`/`pr_url`) is intentionally left as-is — the data is correct for GitLab (MR iid / MR `html_url`) and renaming would break the JSON contract.

## Testing

`cargo test --workspace` passes. Added: `generate_stack_comment` asserts GitLab output uses `!42` (and not `#42`), and a `GitLabClient::pr_reference_prefix() == "!"` unit test. `cargo +1.88 clippy --all-targets --all-features -- -D warnings` and `cargo +1.88 fmt --check` are clean (lint runs on MSRV).
