### PR TITLE
fix(gitlab): forge-aware output + idempotent branch delete (smoke-test findings)

### DIFF
--- a/crates/rung-cli/src/commands/merge.rs
+++ b/crates/rung-cli/src/commands/merge.rs
@@ -203,8 +203,15 @@ async fn execute_merge(
         .clone()
         .unwrap_or_else(|| pr.base_branch.clone());
 
-    // Step 2: Shift child PR bases before merge
-    print_child_relinks(stack, ctx, &parent_branch, json);
+    // Step 2: Shift child PR/MR bases before merge
+    print_child_relinks(
+        stack,
+        ctx,
+        &parent_branch,
+        client.pr_noun(),
+        client.pr_reference_prefix(),
+        json,
+    );
 
     let shifted_prs = service
         .shift_child_pr_bases(stack, &ctx.current_branch, &parent_branch, &ctx.descendants)
@@ -268,7 +275,14 @@ async fn execute_merge(
 }
 
 /// Print info about child PR relinking.
-fn print_child_relinks(stack: &Stack, ctx: &MergeContext, parent_branch: &str, json: bool) {
+fn print_child_relinks(
+    stack: &Stack,
+    ctx: &MergeContext,
+    parent_branch: &str,
+    noun: &str,
+    ref_prefix: &str,
+    json: bool,
+) {
     if json || ctx.descendants.is_empty() {
         return;
     }
@@ -283,7 +297,7 @@ fn print_child_relinks(stack: &Stack, ctx: &MergeContext, parent_branch: &str, j
                 && let Some(child_pr_num) = branch_info.pr
             {
                 output::info(&format!(
-                    "Relinking PR #{child_pr_num} to '{parent_branch}' before merge..."
+                    "Relinking {noun} {ref_prefix}{child_pr_num} to '{parent_branch}' before merge..."
                 ));
             }
         }

--- a/crates/rung-cli/src/commands/status.rs
+++ b/crates/rung-cli/src/commands/status.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use rung_core::State;
-use rung_forge::{ForgeApi, PullRequestState};
+use rung_forge::{ForgeApi, ForgeKind, PullRequestState};
 use rung_git::Repository;
 
 use crate::forge::Forge;
@@ -103,7 +103,19 @@ pub fn run(json: bool, fetch: bool) -> Result<()> {
         let output = JsonOutput::from_branches(&branches_with_pr_status, status.current_branch);
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
-        print_tree(&branches_with_pr_status);
+        // Best-effort forge reference prefix ("#" GitHub / "!" GitLab); no auth
+        // needed — detected from the remote, defaults to "#" when unknown.
+        let ref_prefix = repo
+            .origin_url()
+            .ok()
+            .and_then(|url| {
+                let config = state.load_config().ok()?;
+                crate::forge::parse_remote(&url, &config)
+                    .ok()
+                    .map(|info| info.kind.reference_prefix())
+            })
+            .unwrap_or_else(|| ForgeKind::GitHub.reference_prefix());
+        print_tree(&branches_with_pr_status, ref_prefix);
     }
 
     Ok(())
@@ -148,7 +160,7 @@ fn fetch_pr_statuses(
 }
 
 /// Print a tree view of the stack.
-fn print_tree(branches: &[BranchWithPrStatus]) {
+fn print_tree(branches: &[BranchWithPrStatus], ref_prefix: &str) {
     println!();
     println!("  {}", "Stack".bold());
     output::hr();
@@ -156,7 +168,7 @@ fn print_tree(branches: &[BranchWithPrStatus]) {
     for branch in branches {
         let state_icon = output::state_indicator(&branch.info.state);
         let name = output::branch_name(&branch.info.name, branch.info.is_current);
-        let pr = output::pr_ref(branch.info.pr, branch.display_status);
+        let pr = output::pr_ref(branch.info.pr, branch.display_status, ref_prefix);
 
         let parent_info = branch
             .info

--- a/crates/rung-cli/src/commands/submit.rs
+++ b/crates/rung-cli/src/commands/submit.rs
@@ -125,7 +125,13 @@ pub fn run(
 
     // Single dry-run check point
     if dry_run {
-        return handle_dry_run_output(&plan, json, &config.default_branch);
+        return handle_dry_run_output(
+            &plan,
+            json,
+            &config.default_branch,
+            client.pr_noun(),
+            client.pr_reference_prefix(),
+        );
     }
 
     // Phase 2: Execute the plan (mutations only)
@@ -186,7 +192,7 @@ pub fn run(
         });
     }
 
-    print_summary(created, updated);
+    print_summary(created, updated, client.pr_noun());
 
     Ok(())
 }
@@ -384,12 +390,18 @@ struct DryRunOutput {
 }
 
 /// Handle dry-run output (both JSON and human-readable).
-fn handle_dry_run_output(plan: &SubmitPlan, json: bool, default_branch: &str) -> Result<()> {
+fn handle_dry_run_output(
+    plan: &SubmitPlan,
+    json: bool,
+    default_branch: &str,
+    noun: &str,
+    ref_prefix: &str,
+) -> Result<()> {
     if json {
         return output_dry_run_json(plan);
     }
 
-    print_dry_run_summary(plan, default_branch);
+    print_dry_run_summary(plan, default_branch, noun, ref_prefix);
     Ok(())
 }
 
@@ -433,7 +445,7 @@ fn output_dry_run_json(plan: &SubmitPlan) -> Result<()> {
 }
 
 /// Print human-readable summary for dry-run mode.
-fn print_dry_run_summary(plan: &SubmitPlan, default_branch: &str) {
+fn print_dry_run_summary(plan: &SubmitPlan, default_branch: &str, noun: &str, ref_prefix: &str) {
     if plan.is_empty() {
         output::info("No branches to submit");
         return;
@@ -464,14 +476,14 @@ fn print_dry_run_summary(plan: &SubmitPlan, default_branch: &str) {
     if !updates.is_empty() {
         parts.push(format!("→ Would push {} branches:", updates.len()));
         for (branch, pr_number) in &updates {
-            parts.push(format!("  - {branch} (PR #{pr_number})"));
+            parts.push(format!("  - {branch} ({noun} {ref_prefix}{pr_number})"));
         }
         parts.push(String::new());
     }
 
     if !creates.is_empty() {
         parts.push(format!(
-            "→ Would create {} new PRs for branches:",
+            "→ Would create {} new {noun}s for branches:",
             creates.len()
         ));
         for (branch, base) in &creates {
@@ -533,7 +545,7 @@ fn validate_sync_state(
     Ok(())
 }
 /// Print summary of submit operation.
-fn print_summary(created: usize, updated: usize) {
+fn print_summary(created: usize, updated: usize, noun: &str) {
     if created > 0 || updated > 0 {
         let mut parts = vec![];
         if created > 0 {
@@ -542,7 +554,7 @@ fn print_summary(created: usize, updated: usize) {
         if updated > 0 {
             parts.push(format!("{updated} updated"));
         }
-        output::success(&format!("Done! PRs: {}", parts.join(", ")));
+        output::success(&format!("Done! {noun}s: {}", parts.join(", ")));
     } else {
         output::info("No changes to submit");
     }

--- a/crates/rung-cli/src/output.rs
+++ b/crates/rung-cli/src/output.rs
@@ -103,14 +103,15 @@ pub enum PrStatus {
     Closed,
 }
 
-/// Format a PR reference.
+/// Format a PR/MR reference, using the forge's number prefix (`#` on GitHub,
+/// `!` on GitLab).
 #[must_use]
-pub fn pr_ref(number: Option<u64>, status: Option<PrStatus>) -> String {
+pub fn pr_ref(number: Option<u64>, status: Option<PrStatus>, prefix: &str) -> String {
     let Some(n) = number else {
         return String::new();
     };
 
-    let text = format!("#{n}");
+    let text = format!("{prefix}{n}");
 
     match status {
         Some(PrStatus::Open) => text,                       // Default/White
@@ -141,21 +142,24 @@ mod tests {
         colored::control::set_override(true);
 
         let text = "#42";
-        assert_eq!(pr_ref(None, Some(PrStatus::Open)), "");
-        assert_eq!(pr_ref(Some(42), Some(PrStatus::Open)), text);
+        assert_eq!(pr_ref(None, Some(PrStatus::Open), "#"), "");
+        assert_eq!(pr_ref(Some(42), Some(PrStatus::Open), "#"), text);
         assert_eq!(
-            pr_ref(Some(42), Some(PrStatus::Draft)),
+            pr_ref(Some(42), Some(PrStatus::Draft), "#"),
             text.yellow().to_string()
         );
         assert_eq!(
-            pr_ref(Some(42), Some(PrStatus::Merged)),
+            pr_ref(Some(42), Some(PrStatus::Merged), "#"),
             text.green().to_string()
         );
         assert_eq!(
-            pr_ref(Some(42), Some(PrStatus::Closed)),
+            pr_ref(Some(42), Some(PrStatus::Closed), "#"),
             text.red().to_string()
         );
-        assert_eq!(pr_ref(Some(42), None), text.dimmed().to_string());
+        assert_eq!(pr_ref(Some(42), None, "#"), text.dimmed().to_string());
+
+        // GitLab uses `!` for merge-request references.
+        assert_eq!(pr_ref(Some(42), Some(PrStatus::Open), "!"), "!42");
 
         colored::control::set_override(false);
     }
@@ -204,14 +208,14 @@ mod tests {
 
     #[test]
     fn test_pr_ref_some() {
-        let pr = pr_ref(Some(123), None);
+        let pr = pr_ref(Some(123), None, "#");
         assert!(pr.contains("123"));
         assert!(pr.contains('#'));
     }
 
     #[test]
     fn test_pr_ref_none() {
-        let pr = pr_ref(None, None);
+        let pr = pr_ref(None, None, "#");
         assert!(pr.is_empty());
     }
 

--- a/crates/rung-forge/src/remote.rs
+++ b/crates/rung-forge/src/remote.rs
@@ -32,6 +32,19 @@ impl ForgeKind {
         }
     }
 
+    /// Markdown/reference prefix for a change request number: `#` on GitHub,
+    /// `!` on GitLab (where `#` refers to an issue). Mirrors
+    /// [`ForgeApi::pr_reference_prefix`](crate::ForgeApi::pr_reference_prefix)
+    /// for contexts that have a [`ForgeKind`] but no authenticated client (e.g.
+    /// rendering the status tree without contacting the forge).
+    #[must_use]
+    pub const fn reference_prefix(self) -> &'static str {
+        match self {
+            Self::GitHub => "#",
+            Self::GitLab => "!",
+        }
+    }
+
     /// Hint describing how to authenticate with this forge, for error messages.
     #[must_use]
     pub const fn auth_hint(self) -> &'static str {

--- a/crates/rung-gitlab/src/client.rs
+++ b/crates/rung-gitlab/src/client.rs
@@ -559,12 +559,21 @@ impl ForgeApi for GitLabClient {
         // The forge-neutral ref name is a branch name; tolerate a `refs/heads/`
         // prefix, then encode it as GitLab addresses branches by name.
         let branch = ref_name.strip_prefix("refs/heads/").unwrap_or(ref_name);
-        self.delete(&format!(
-            "/projects/{}/repository/branches/{}",
-            project(repo),
-            encode(branch)
-        ))
-        .await
+        let result = self
+            .delete(&format!(
+                "/projects/{}/repository/branches/{}",
+                project(repo),
+                encode(branch)
+            ))
+            .await;
+        // GitLab often auto-deletes the source branch when a merge request is
+        // merged, so a follow-up delete can 404. Deletion is idempotent: treat
+        // an already-gone branch as success rather than surfacing a scary
+        // "failed to delete" warning.
+        match result {
+            Err(Error::ApiError { status: 404, .. }) => Ok(()),
+            other => other,
+        }
     }
 
     async fn get_default_branch(&self, repo: &RepoId) -> Result<String> {
@@ -1217,6 +1226,30 @@ mod tests {
         assert!(
             client
                 .delete_ref(&RepoId::new("owner/repo"), "feature-branch")
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_ref_already_deleted_is_ok() {
+        // GitLab auto-deletes the source branch on merge, so a follow-up delete
+        // 404s; deletion is idempotent and must not surface an error.
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/projects/owner%2Frepo/repository/branches/gone-branch",
+            ))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "404 Branch Not Found"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri());
+        assert!(
+            client
+                .delete_ref(&RepoId::new("owner/repo"), "gone-branch")
                 .await
                 .is_ok()
         );


### PR DESCRIPTION
## Summary

Fixes the loose ends found by the GitLab smoke test against a live gitlab.com project: a misleading merge warning and several remaining GitHub-only output strings. Each fix was re-verified end-to-end on real MRs.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [x] I have added/updated tests for these changes
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — n/a
- [x] **Documentation**: I have added doc comments (`///`) to new public functions

## Change Description

- **Type of change**: Bug fix (UX correctness)
- **Current behavior (on GitLab)**:
  - `rung merge` printed **"Failed to delete remote branch"** on every merge — GitLab auto-deletes the source branch on merge, so rung's follow-up delete 404'd even though the branch was gone.
  - Several output strings still said "PR"/"#" instead of "MR"/"!": `submit` summary ("Done! PRs:"), `submit --dry-run` ("new PRs", "(PR #N)"), `merge` ("Relinking PR #N"), and the `status` tree (`#N`).
- **New behavior**:
  - `GitLabClient::delete_ref` is now idempotent — a 404 (branch already gone) is treated as success, so no spurious warning. Branch is still deleted as intended.
  - Forge-aware wording everywhere via `ForgeApi::pr_noun()` / `pr_reference_prefix()`; added `ForgeKind::reference_prefix()` for the status tree (which renders without an authenticated client). GitLab now shows "MR !N" / "MRs:" / "!N" throughout.
- **Breaking changes?**: No.

## Testing

Added unit tests: `delete_ref` 404-is-ok, `pr_ref` with `!` prefix. `cargo test --workspace` passes; `cargo +1.88 clippy --all-targets --all-features -- -D warnings` and `cargo +1.88 fmt --check` clean (lint on MSRV).

**Re-verified live on gitlab.com/austin-software/rung-test:**
- `submit` → "Done! MRs: 2 created"
- `status` tree → `feat-alpha !3 ← main`
- `submit --dry-run` → "feat-beta (MR !4)"
- `merge` → "Relinking MR !4", "Merged MR !3", "Deleted remote branch" (no failure warning)
