### PR TITLE
chore(homebrew): update formula to v1.0.0

### DIFF
--- a/Formula/rung.rb
+++ b/Formula/rung.rb
@@ -1,8 +1,8 @@
 class Rung < Formula
-  desc "Git workflow tool for managing stacked PRs"
+  desc "Git workflow tool for managing stacked pull and merge requests"
   homepage "https://github.com/auswm85/rung"
-  url "https://github.com/auswm85/rung/archive/refs/tags/v0.9.0.tar.gz"
-  sha256 "80d5113b1222d5ef6dee322425dcc26d4d0e6de5c35c70cc9d9d74f680f02b41"
+  url "https://github.com/auswm85/rung/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "857b9a90569cb9986d57247acae1b72768551b75ab0120d0c1ddc5328cc67057"
   license "MIT"
 
   depends_on "rust" => :build


### PR DESCRIPTION
Bumps the Homebrew formula to v1.0.0 (released via the `v1.0.0` tag).

- `url` → v1.0.0 source tarball
- `sha256` updated (verified: tarball contains `version = "1.0.0"`)
- `desc` broadened to reflect GitHub + GitLab support

`brew install rung` picks this up once merged.