### PR TITLE
test: use assert_eq! for branch name equality assertions

### DIFF
--- a/crates/rung-cli/tests/integration.rs
+++ b/crates/rung-cli/tests/integration.rs
@@ -250,8 +250,9 @@ fn test_create_branch() {
         .expect("Failed to get current branch");
 
     let current_branch = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        current_branch.trim() == "feature-1",
+    assert_eq!(
+        current_branch.trim(),
+        "feature-1",
         "Should be on feature-1 branch"
     );
 
@@ -353,7 +354,7 @@ fn test_navigate_up_down() {
         .expect("Failed to get current branch");
 
     let current_branch = String::from_utf8_lossy(&output.stdout);
-    assert!(current_branch.trim() == "main", "Should be on main branch");
+    assert_eq!(current_branch.trim(), "main", "Should be on main branch");
 
     // Navigate to child (feature-1)
     rung().arg("nxt").current_dir(&temp).assert().success();
@@ -365,8 +366,9 @@ fn test_navigate_up_down() {
         .expect("Failed to get current branch");
 
     let current_branch = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        current_branch.trim() == "feature-1",
+    assert_eq!(
+        current_branch.trim(),
+        "feature-1",
         "Should be on feature-1 branch"
     );
 }
@@ -1969,7 +1971,7 @@ fn test_prv_alias() {
         .expect("Failed to get current branch");
 
     let branch = String::from_utf8_lossy(&output.stdout);
-    assert!(branch.trim() == "main");
+    assert_eq!(branch.trim(), "main");
 }
 
 #[test]
@@ -2002,7 +2004,7 @@ fn test_nxt_alias() {
         .expect("Failed to get current branch");
 
     let branch = String::from_utf8_lossy(&output.stdout);
-    assert!(branch.trim() == "feature-nav-2");
+    assert_eq!(branch.trim(), "feature-nav-2");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Unblocks the local pre-commit hook, which fails on `main` under current stable Rust.

`cargo clippy` errors on two pre-existing `clippy::manual_assert_eq` violations in `crates/rung-cli/tests/integration.rs` (introduced in #110). CI does not see them because the Lint job pins `dtolnay/rust-toolchain@1.88`, where that lint does not yet exist; local `rustup` default is `stable` (rustc 1.97.0, released 2026-07-07). Both run `-D warnings`, so any lint added after 1.88 is a hard error locally and invisible in CI.

The code has not changed since February — the toolchains drifted apart.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes — n/a, existing assertions rewritten
- [ ] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — n/a
- [ ] **Documentation**: I have added doc comments (`///`) to new public functions — n/a

## Change Description

- **Type of change**: Test cleanup
- **Current behavior**: `assert!(a == b)` fails `clippy::manual_assert_eq` on rustc >= ~1.9x; pre-commit hook blocks every commit
- **New behavior**: `assert_eq!`, clean under both the hook's and CI's clippy invocations
- **Breaking changes?**: None. `assert_eq!` long predates MSRV 1.88.

Five sites in `crates/rung-cli/tests/integration.rs` — lines ~253, 356, ~369, 1972, 2005.

Lines 1972 and 2005 are the two clippy flagged. The other three are the same pattern but invisible to the lint, which skips comparisons carrying a custom message; `assert_eq!` also gives better failure output (prints left/right rather than just "assertion failed").

Verified:

| Check | Result |
| --- | --- |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` (1.97) | pass |
| `cargo +1.88 clippy --workspace --all-targets --all-features -- -D warnings` (MSRV) | pass |
| `cargo fmt --all --check` | pass |
| `test_create_branch`, `test_navigate_up_down`, `test_prv_alias`, `test_nxt_alias` | pass |

Sites deliberately left alone — converting them would change what is asserted, not just how it is written:

- `submit.rs:865,866,893,894,925` — assert on `<` between two `position()` results; the `==` is inside a closure
- `repository.rs:1144` — `||` disjunction
- `repository.rs:1196,1197`, `merge.rs:1069`, `repository.rs:1391` — `any()` predicates

- `submit.rs:865,866,893,894` — assert on `<` between two `position()` results; the `==` is inside a closure
- `repository.rs:1144` — `||` disjunction
- `repository.rs:1196,1197` — `any()` predicates

## Other Information

This unblocks the hook but does not fix the underlying drift: local floats on `stable` while CI is pinned to 1.88, so the next stable release adding a lint will break the hook the same way. Worth deciding separately whether to pin local via `rust-toolchain.toml` or move the CI pin forward.

Also note `manual_assert_eq` ignores asserts with a custom message, so clippy alone will not keep this consistent — a future `assert!(a == b, "msg")` passes CI silently.

Two unrelated divergences between the hook and CI, not addressed here:

```
hook: cargo clippy --workspace --all-targets                -- -D warnings
CI:   cargo clippy             --all-targets --all-features -- -D warnings
```

Neither flag set is a superset of the other.

