### PR TITLE
ci: run pre-commit lint on the MSRV toolchain to match CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,6 +3,10 @@
 # Runs cargo fmt --check and cargo clippy before commits.
 #
 # Setup: git config core.hooksPath .githooks
+#
+# Checks run on the MSRV toolchain to mirror the CI Lint job. Linting on
+# floating stable instead would surface lints that do not exist at MSRV, so
+# commits would be blocked by errors CI never reports (see ci.yml, job `lint`).
 
 # Ensure cargo is in PATH
 export PATH="$HOME/.cargo/bin:$PATH"
@@ -11,16 +15,26 @@ set -e
 
 echo "Running pre-commit checks..."
 
+# Read MSRV from the workspace manifest so this never drifts from Cargo.toml.
+MSRV=$(grep -m1 '^rust-version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+
+TOOLCHAIN=""
+if [ -n "$MSRV" ] && rustup toolchain list 2>/dev/null | grep -q "^$MSRV"; then
+    TOOLCHAIN="+$MSRV"
+    echo "  using Rust $MSRV (MSRV)"
+else
+    echo "  ⚠ Rust $MSRV not installed; using default toolchain."
+    echo "    CI lints on $MSRV — install it to match: rustup toolchain install $MSRV"
+fi
+
 echo "→ cargo fmt --check"
-cargo fmt --check
-if [ $? -ne 0 ]; then
-    echo "✗ Format check failed. Run 'cargo fmt' to fix."
+if ! cargo $TOOLCHAIN fmt --all -- --check; then
+    echo "✗ Format check failed. Run 'cargo fmt --all' to fix."
     exit 1
 fi
 
 echo "→ cargo clippy"
-cargo clippy --workspace --all-targets -- -D warnings
-if [ $? -ne 0 ]; then
+if ! cargo $TOOLCHAIN clippy --workspace --all-targets --all-features -- -D warnings; then
     echo "✗ Clippy found issues."
     exit 1
 fi


### PR DESCRIPTION
## Summary

Runs the pre-commit hook's checks on the MSRV toolchain, mirroring the CI `lint` job.

The hook ran on whatever `rustup` defaults to — floating `stable`. CI deliberately lints on MSRV (`ci.yml:43-47`) so lint behavior is tied to the compiler version the project supports. Those two diverged when stable moved to 1.97 on 2026-07-07: the hook began failing on lints that do not exist at 1.88, blocking every local commit with errors CI never reports.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes — n/a, git hook
- [ ] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — n/a
- [ ] **Documentation**: I have added doc comments (`///`) to new public functions — n/a

## Change Description

- **Type of change**: Developer tooling
- **Current behavior**: Hook lints on floating `stable`; fails on lints CI does not have
- **New behavior**: Hook lints on MSRV, matching CI; falls back to the default toolchain with a warning if MSRV is not installed
- **Breaking changes?**: None. Contributors without the MSRV toolchain get a warning and the previous behavior, not a hard failure.

### Toolchain

MSRV is parsed from `Cargo.toml` rather than hardcoded, so the hook cannot drift from `rust-version` on the next bump:

```sh
MSRV=$(grep -m1 '^rust-version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
```

If that toolchain is not installed the hook prints an install hint and proceeds on the default toolchain, so it never blocks a contributor who has not run `rustup toolchain install 1.88`.

### Flags aligned with CI

The hook and CI were checking different surfaces — neither flag set was a superset of the other:

```
before  hook: cargo fmt --check         | cargo clippy --workspace --all-targets                -- -D warnings
        CI:   cargo fmt --all -- --check| cargo clippy             --all-targets --all-features -- -D warnings

after   hook: cargo fmt --all -- --check| cargo clippy --workspace --all-targets --all-features -- -D warnings
```

### Error messages now actually fire

With `set -e`, the existing `if [ $? -ne 0 ]` blocks were unreachable — the script exited on the failing command before the check ran, so "Run 'cargo fmt' to fix" never printed. Rewritten as `if ! cargo ...; then`.

## Other Information

Verified by running `sh .githooks/pre-commit` directly: reports `using Rust 1.88 (MSRV)`, and both checks pass. The commit on this branch was itself made through the hook with no bypass.

This addresses the local/CI divergence but does not change MSRV. Whether 1.88 should move forward is a separate question — the pin is currently ~9 releases behind stable.
