### PR TITLE
ci: stop dependabot bumping the dtolnay/rust-toolchain MSRV pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,5 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      - dependency-name: dtolnay/rust-toolchain


### PR DESCRIPTION
## Summary

Stops Dependabot from bumping the `dtolnay/rust-toolchain` pin, which tracks MSRV rather than an action version.

`dtolnay/rust-toolchain` publishes a branch per Rust version instead of semver tags, including placeholders for versions that have not shipped. Dependabot ranks those numerically, so it opened #195 proposing `1.88 -> 1.100` — but Rust 1.100.0 does not exist (`rust-lang/rust` returns 404 for that tag; current stable is 1.97.0). The `1.100` branch was committed 2026-07-16 with message `toolchain: 1.100.0` as a placeholder.

The ref it wanted to change is `ci.yml:49`, the MSRV lint pin added on 2026-07-11 specifically to stop stable drift from breaking CI.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes — n/a, Dependabot config
- [ ] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands) — n/a
- [ ] **Documentation**: I have added doc comments (`///`) to new public functions — n/a

## Change Description

- **Type of change**: CI configuration
- **Current behavior**: Dependabot proposes moving the MSRV lint pin to unreleased Rust versions, and will keep re-proposing on every run
- **New behavior**: `dtolnay/rust-toolchain` is ignored; the pin is bumped deliberately alongside `rust-version` in `Cargo.toml`
- **Breaking changes?**: None. All other actions remain covered by the grouped weekly update.

Merging #195 would also have desynced the two MSRV pins: it only touches `ci.yml:49`, because the `msrv` job at `ci.yml:143` uses `@master` with `toolchain: "1.88"` as an input, which Dependabot cannot see.

## Other Information

**#195 should be closed**, not merged.

Follow-up worth considering: switching `ci.yml:49` to the `@master` + `toolchain:` input form the `msrv` job already uses would make both pins plain strings that Dependabot cannot misread, and would make the two consistent. Left out of this PR to keep it to the fix.
