### PR TITLE
chore: raise MSRV from 1.88 to 1.97

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,12 @@ jobs:
       # Lint on the MSRV toolchain (not floating stable) so clippy/rustfmt
       # behavior is tied to the compiler version the project commits to
       # support. This keeps lint results deterministic: a newer stable clippy
-      # cannot introduce lints that break CI without an MSRV bump. The `@1.88`
-      # ref is the action's version-pinned branch, avoiding the moving `@master`.
+      # cannot introduce lints that break CI without an MSRV bump. Keep the
+      # toolchain here in sync with `rust-version` in Cargo.toml.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: "1.97"
           components: rustfmt, clippy
 
       - name: Cache cargo registry
@@ -130,7 +131,7 @@ jobs:
 
   # MSRV check
   msrv:
-    name: MSRV (1.88)
+    name: MSRV (1.97)
     needs: changes
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
@@ -140,7 +141,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.88"
+          toolchain: "1.97"
 
       - name: Cache cargo registry
         uses: actions/cache@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "1.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/auswm85/rung"
-rust-version = "1.88"
+rust-version = "1.97"
 
 [workspace.dependencies]
 # Internal crates

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Crates.io](https://img.shields.io/crates/v/rung-cli.svg)](https://crates.io/crates/rung-cli)
 [![CI](https://github.com/auswm85/rung/actions/workflows/ci.yml/badge.svg)](https://github.com/auswm85/rung/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.88-orange.svg)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.97-orange.svg)](https://www.rust-lang.org)
 
 A Git workflow tool for managing stacked pull requests (GitHub) and merge requests (GitLab) — chains of dependent branches.
 
@@ -446,7 +446,7 @@ Rung stores its state in `.git/rung/`:
 
 ## Requirements
 
-- Rust 1.88+
+- Rust 1.97+
 - Git 2.x
 - A forge credential for your remote:
   - **GitHub** — GitHub CLI (`gh`) authenticated, or `GITHUB_TOKEN` environment variable

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -101,4 +101,4 @@ $ rung sync
 
 - Git 2.x
 - GitHub CLI (`gh`) / `GITHUB_TOKEN`, or GitLab CLI (`glab`) / `GITLAB_TOKEN`
-- Rust 1.88+ (for building from source)
+- Rust 1.97+ (for building from source)


### PR DESCRIPTION
## Summary

Raises MSRV from 1.88 to 1.97, and normalizes both toolchain pins to the same form.

1.88.0 shipped 2025-06-26 — 9 releases and ~13 months behind current stable (1.97.0, 2026-07-09). Linting on a toolchain that old means the project never sees lints added since, which is how `clippy::manual_assert_eq` sat undetected in the test suite until #196.

## Checklist

- [x] I have followed the [Branch Naming and Commit guidelines](CONTRIBUTING.md)
- [x] `cargo fmt`, `clippy`, and `test` pass locally
- [ ] I have added/updated tests for these changes — n/a, no code change
- [x] **Documentation**: I have updated the `README.md` (if adding/changing CLI commands)
- [ ] **Documentation**: I have added doc comments (`///`) to new public functions — n/a

## Change Description

- **Type of change**: Chore / CI configuration
- **Current behavior**: MSRV 1.88; lint runs on a ~13-month-old clippy
- **New behavior**: MSRV 1.97; lint runs on current stable's clippy
- **Breaking changes?**: Yes for consumers — see below

### Sites changed (8)

| File | Change |
| --- | --- |
| `Cargo.toml:10` | `rust-version = "1.88"` → `"1.97"` |
| `.github/workflows/ci.yml:43-52` | lint pin form + toolchain, comment corrected |
| `.github/workflows/ci.yml:134` | job name `MSRV (1.88)` → `MSRV (1.97)` |
| `.github/workflows/ci.yml:144` | msrv job `toolchain: "1.88"` → `"1.97"` |
| `README.md:10` | MSRV badge |
| `README.md:440` | `Rust 1.88+` → `Rust 1.97+` |
| `site/src/content/docs/index.mdx:104` | `Rust 1.88+` → `Rust 1.97+` |

The six crate manifests need no change — they inherit via `rust-version.workspace = true`. The pre-commit hook needs no change either: since #197 it parses MSRV out of `Cargo.toml`, and it picked up 1.97 automatically when this commit was made.

### Pin form normalized

The lint job moves from a version-named branch to the input form the `msrv` job already used, so both pins are now identical:

```yaml
uses: dtolnay/rust-toolchain@master
with:
  toolchain: "1.97"
```

Two reasons:

1. Version strings are now plain inputs Dependabot cannot misread as semver tags. That misread produced #195, which proposed `1.88 -> 1.100` for a Rust version that does not exist. #198 works around it with an `ignore` rule; this removes the ambiguity at the source.
2. It corrects a wrong assumption in the old comment, which claimed the `@1.88` ref avoided "the moving `@master`". The version branches move too — every one was re-committed 2026-07-16, five days after the pin was added:

```
master -> 2c7215f132e9  2026-07-16  "Add 1.97.1 patch release"
1.97   -> 46511b1c8343  2026-07-16  "toolchain: 1.97.1"
1.88   -> 39b0b3842c7e  2026-07-16  "toolchain: 1.88.0"
```

`@1.88` pinned the Rust version but not the action code. Neither branch form is immutable; only a SHA is. This change keeps the same guarantee as before while making the Rust version explicit.

### Verification

All run against this branch on 1.97:

| Check | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --all-targets --all-features -- -D warnings` | pass |
| `cargo check --all-targets --all-features` (msrv job) | pass |
| `cargo doc --no-deps --all-features` | pass |
| `cargo test --workspace` | 626 passed, 0 failed |

Floor is enforced — building on the old toolchain now fails as intended:

```
error: rustc 1.88.0 is not supported by the following packages:
  rung-core@1.0.0 requires rustc 1.97
```

Zero source changes were required; #196 cleared the only blocker.

## Other Information

**Who this affects.** Prebuilt paths are unaffected — `install.sh`, Homebrew, and `cargo binstall` ship binaries and never compile. That covers most users.

Source installers on rustc < 1.97 are affected once 1.1.0 is published. Cargo has no MSRV-aware fallback for `cargo install`: it does not silently pick an older compatible version, it errors. Per the Cargo book, "when your package is compiled on an unsupported toolchain, Cargo will report that as an error to the user." So the bare command fails:

```
cargo install rung-cli          # errors: requires rustc 1.97
```

Three documented ways through:

```bash
cargo install rung-cli --version 1.0.0        # last MSRV-1.88 release
cargo install rung-cli --ignore-rust-version  # documented escape hatch
rustup update                                 # or just update Rust
```

Pinning `--version 1.0.0` keeps working because publishing 1.1.0 does not retroactively change 1.0.0's `rust-version` on crates.io. The same applies to anyone depending on the six library crates: they need 1.97 or a `=1.0.0` pin.

The failure is a clear toolchain error rather than a confusing compile error — which is the stated reason Cargo checks `rust-version` at all.

**Version bump.** MSRV raises the floor for six crates published at 1.0.0, which conventionally warrants a minor bump. Suggest `1.1.0` at the next release rather than a patch. Not done here.

